### PR TITLE
feat: rex balance --token <address>

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -166,13 +166,12 @@ impl Command {
                 eth,
                 rpc_url,
             } => {
-                if token_address.is_some() {
-                    todo!("Handle ERC20 balances")
-                }
-
                 let eth_client = EthClient::new(&rpc_url);
-
-                let account_balance = eth_client.get_balance(account).await?;
+                let account_balance = if let Some(token_address) = token_address {
+                    eth_client.get_token_balance(account, token_address).await?
+                } else {
+                    eth_client.get_balance(account).await?
+                };
 
                 println!("{}", balance_in_eth(eth, account_balance));
             }


### PR DESCRIPTION
**Description**

This PR implements the `--token` flag for the `rex balance` command. To get the token balance for an address we call the contract function `balanceOf(address)` the calldata is created by the selector `0x70a08231` 16 bytes of padding, then the address of the account we are querying.

**Syntax**

```Shell
rex balance <ACCOUNT> --token <TOKEN_ADDRESS>
```