### PR TITLE
fix(cli): make private key optional

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -42,7 +42,7 @@ pub struct TransferArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+    #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
 }
 
@@ -80,7 +80,7 @@ pub struct SendArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+    #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
 }
 
@@ -143,6 +143,6 @@ pub struct DeployArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+    #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
 }


### PR DESCRIPTION
**Motivation**

Currently the following error appears when running the `send` command.

`Found non-required positional argument with a lower index than a required positional argument: "value" index Some(2)`

**Description**

Since the private key is a required parameter, it needs to be together with the positional arguments but this would interfere with providing it as an env variable.

This solves it by making the private key optional.
