### PR TITLE
fix(cli): `rex signer` cmd

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,20 +1,10 @@
-use ethrex_common::{Bytes, H256, U256};
+use ethrex_common::{Bytes, U256};
 use hex::FromHexError;
 use secp256k1::SecretKey;
 use std::str::FromStr;
 
 pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
     Ok(SecretKey::from_slice(&parse_hex(s)?)?)
-}
-
-pub fn parse_message(s: &str) -> eyre::Result<secp256k1::Message> {
-    let parsed = secp256k1::Message::from_digest(*parse_h256(s)?.as_fixed_bytes());
-    Ok(parsed)
-}
-
-pub fn parse_h256(s: &str) -> eyre::Result<H256> {
-    let parsed = H256::from_slice(&parse_hex(s)?);
-    Ok(parsed)
 }
 
 pub fn parse_u256(s: &str) -> eyre::Result<U256> {


### PR DESCRIPTION
**Motivation**

There was a bug in `rex signer` implementation.

**Description**

Builds the signed message payload correctly.

**How to test**

> [!IMPORTANT]
> To use `rex sign` you need #103.

```Shell
// 1. Sign a message using a private key.
rex sign 0x779172e004a01f01249038ed576516345ee9ce46a5e678b61945f33eff7448bb 0x052d7e212b30b505f337b0be5cf953c3d3175724f337b0be5cf953c3d3175724

// 2. Retrieve the signer.
rex signer 0x779172e004a01f01249038ed576516345ee9ce46a5e678b61945f33eff7448bb 0x59fa0ee54bc49b8130b465a2b378674ad70675e608407d30fe0289c800889b81167eb8e34007c5afbc845866d809583939f3a25dbae1c81ff6bf6959827b91ad1c

// 3. Check that the signer corresponds to the address associated to the private key used before.
rex address --from-private-key 0x052d7e212b30b505f337b0be5cf953c3d3175724f337b0be5cf953c3d3175724
0x559778627fbe1591d72971915ec91fb8eb55bbc9
```

1. 

