### PR TITLE
feat(cli): allow calling/sending using signatures

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -224,13 +224,12 @@ Options:
 ```Shell
 Send a transaction
 
-Usage: rex send [OPTIONS] <TO> [VALUE] <PRIVATE_KEY> [RPC_URL]
+Usage: rex send [OPTIONS] <TO> [VALUE] <PRIVATE_KEY> -- [SIGNATURE [ARGS]]
 
 Arguments:
   <TO>
   [VALUE]        Value to send in wei [default: 0]
   <PRIVATE_KEY>  [env: PRIVATE_KEY=]
-  [RPC_URL]      [env: RPC_URL=] [default: http://localhost:8545]
 
 Options:
       --calldata <CALLDATA>                            [default: ]
@@ -239,7 +238,8 @@ Options:
       --gas-limit <GAS_LIMIT>
       --gas-price <MAX_FEE_PER_GAS>
       --priority-gas-price <MAX_PRIORITY_FEE_PER_GAS>
-  -b                                                   Do not wait for the transaction receipt
+      --rpc-url <RPC_URL>                              [env: RPC_URL=] [default: http://localhost:8545]
+      -b                                               Do not wait for the transaction receipt
       --explorer-url                                   Display transaction URL in the explorer.
   -h, --help                                           Print help
 ```
@@ -249,19 +249,19 @@ Options:
 ```Shell
 Make a call to a contract
 
-Usage: rex call [OPTIONS] <TO> [CALLDATA] [VALUE] [RPC_URL]
+Usage: rex call [OPTIONS] <TO> [CALLDATA] [VALUE]  -- [SIGNATURE [ARGS]]
 
 Arguments:
   <TO>
   [CALLDATA]  [default: ]
   [VALUE]     Value to send in wei [default: 0]
-  [RPC_URL]   [env: RPC_URL=] [default: http://localhost:8545]
 
 Options:
       --from <FROM>
       --gas-limit <GAS_LIMIT>
       --max-fee-per-gas <MAX_FEE_PER_GAS>
       --explorer-url                       Display transaction URL in the explorer.
+      --rpc-url <RPC_URL>                  [env: RPC_URL=] [default: http://localhost:8545]
   -h, --help                               Print help
 ```
 

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -82,12 +82,14 @@ pub struct SendArgs {
     pub explorer_url: bool,
     #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
+    #[arg(last=true, hide=true)]
+    pub _args: Vec<String>,
 }
 
 #[derive(Parser)]
 pub struct CallArgs {
     pub to: Address,
-    #[clap(value_parser = parse_hex, required = false, default_value = "")]
+    #[clap(long, value_parser = parse_hex, required = false, default_value = "")]
     pub calldata: Bytes,
     #[clap(
         value_parser = parse_u256,
@@ -108,6 +110,8 @@ pub struct CallArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
+    #[arg(last=true, hide=true)]
+    pub _args: Vec<String>,
 }
 
 #[derive(Parser)]

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,7 +1,8 @@
-use ethrex_common::{Bytes, H256, U256};
+use ethrex_common::{Address, Bytes, H256, U256};
 use hex::FromHexError;
 use secp256k1::SecretKey;
 use std::str::FromStr;
+use rex_sdk::calldata::{encode_calldata, parse_signature, Value};
 
 pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
     Ok(SecretKey::from_slice(&parse_hex(s)?)?)
@@ -31,4 +32,40 @@ pub fn parse_hex(s: &str) -> eyre::Result<Bytes, FromHexError> {
         Some(s) => hex::decode(s).map(Into::into),
         None => hex::decode(s).map(Into::into),
     }
+}
+
+pub fn parse_func_call(args: Vec<String>) -> eyre::Result<Bytes> {
+    let mut args_iter = args.iter();
+    let Some(signature) = args_iter.next() else {
+        return Ok(Bytes::new());
+    };
+    let (_, params) = parse_signature(&signature)?;
+    let mut values = Vec::new();
+    for param in params {
+        let val = args_iter.next()
+            .ok_or(eyre::Error::msg("missing parameter for given signature"))?;
+        values.push(match param.as_str() {
+            "address" => Value::Address(Address::from_str(&val)?),
+            _ if param.starts_with("uint") => Value::Uint(U256::from_dec_str(&val)?),
+            _ if param.starts_with("int") => if val.starts_with("-") {
+                let x = U256::from_dec_str(&val[1..])?;
+                if x.is_zero() {
+                    Value::Uint(x)
+                } else {
+                    Value::Uint(U256::max_value() - x + 1)
+                }
+            } else {
+                Value::Uint(U256::from_dec_str(&val)?)
+            },
+            "bool" => match val.as_str() {
+                "true" => Value::Uint(U256::from(1)),
+                "false" => Value::Uint(U256::from(0)),
+                _ => Err(eyre::Error::msg("Invalid boolean"))?
+            },
+            "bytes" => Value::Bytes(hex::decode(&val)?.into()),
+            _ if param.starts_with("bytes") => Value::FixedBytes(hex::decode(&val)?.into()),
+            _ => todo!("type unsupported")
+        });
+    }
+    Ok(encode_calldata(&signature, &values)?.into())
 }

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -376,6 +376,7 @@ impl EthClient {
                     if &error_data == "0x" {
                         "unknown error".to_owned()
                     } else {
+println!("{error_data}");
                         let abi_decoded_error_data = hex::decode(
                             error_data.strip_prefix("0x").ok_or(EthClientError::Custom(
                                 "Failed to strip_prefix in estimate_gas".to_owned(),


### PR DESCRIPTION
**Motivation**

Having to manually construct calldata is annoying and inconvenient.

**Description**

This implements support for basic types (fixed/ufixed, function and tuples are not implemented).

Closes #106

