### PR TITLE
fix(cli): fix chain-id arguments

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -81,7 +81,6 @@ pub(crate) enum Command {
     #[clap(about = "Get the network's chain id.")]
     ChainId {
         #[arg(
-            short,
             long,
             default_value_t = false,
             help = "Display the chain id as a hex-string."

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -82,7 +82,7 @@ pub struct SendArgs {
     pub explorer_url: bool,
     #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
-    #[arg(last=true, hide=true)]
+    #[arg(last = true, hide = true)]
     pub _args: Vec<String>,
 }
 
@@ -110,7 +110,7 @@ pub struct CallArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[arg(last=true, hide=true)]
+    #[arg(last = true, hide = true)]
     pub _args: Vec<String>,
 }
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,8 +1,8 @@
 use ethrex_common::{Address, Bytes, H256, U256};
 use hex::FromHexError;
+use rex_sdk::calldata::{Value, encode_calldata, parse_signature};
 use secp256k1::SecretKey;
 use std::str::FromStr;
-use rex_sdk::calldata::{encode_calldata, parse_signature, Value};
 
 pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
     Ok(SecretKey::from_slice(&parse_hex(s)?)?)
@@ -42,29 +42,32 @@ pub fn parse_func_call(args: Vec<String>) -> eyre::Result<Bytes> {
     let (_, params) = parse_signature(&signature)?;
     let mut values = Vec::new();
     for param in params {
-        let val = args_iter.next()
+        let val = args_iter
+            .next()
             .ok_or(eyre::Error::msg("missing parameter for given signature"))?;
         values.push(match param.as_str() {
             "address" => Value::Address(Address::from_str(&val)?),
             _ if param.starts_with("uint") => Value::Uint(U256::from_dec_str(&val)?),
-            _ if param.starts_with("int") => if val.starts_with("-") {
-                let x = U256::from_dec_str(&val[1..])?;
-                if x.is_zero() {
-                    Value::Uint(x)
+            _ if param.starts_with("int") => {
+                if val.starts_with("-") {
+                    let x = U256::from_dec_str(&val[1..])?;
+                    if x.is_zero() {
+                        Value::Uint(x)
+                    } else {
+                        Value::Uint(U256::max_value() - x + 1)
+                    }
                 } else {
-                    Value::Uint(U256::max_value() - x + 1)
+                    Value::Uint(U256::from_dec_str(&val)?)
                 }
-            } else {
-                Value::Uint(U256::from_dec_str(&val)?)
-            },
+            }
             "bool" => match val.as_str() {
                 "true" => Value::Uint(U256::from(1)),
                 "false" => Value::Uint(U256::from(0)),
-                _ => Err(eyre::Error::msg("Invalid boolean"))?
+                _ => Err(eyre::Error::msg("Invalid boolean"))?,
             },
             "bytes" => Value::Bytes(hex::decode(&val)?.into()),
             _ if param.starts_with("bytes") => Value::FixedBytes(hex::decode(&val)?.into()),
-            _ => todo!("type unsupported")
+            _ => todo!("type unsupported"),
         });
     }
     Ok(encode_calldata(&signature, &values)?.into())

--- a/sdk/src/calldata.rs
+++ b/sdk/src/calldata.rs
@@ -37,7 +37,11 @@ pub fn parse_signature(signature: &str) -> Result<(String, Vec<String>), Calldat
         .split(',')
         .map(|x| x.trim().split_once(' ').unzip().0.unwrap_or(x).to_string())
         .collect();
-    if params.first().ok_or(CalldataEncodeError::InternalError)?.is_empty() {
+    if params
+        .first()
+        .ok_or(CalldataEncodeError::InternalError)?
+        .is_empty()
+    {
         Ok((name.to_string(), vec![]))
     } else {
         Ok((name.to_string(), params))

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -376,7 +376,7 @@ impl EthClient {
                     if &error_data == "0x" {
                         "unknown error".to_owned()
                     } else {
-println!("{error_data}");
+                        println!("{error_data}");
                         let abi_decoded_error_data = hex::decode(
                             error_data.strip_prefix("0x").ok_or(EthClientError::Custom(
                                 "Failed to strip_prefix in estimate_gas".to_owned(),


### PR DESCRIPTION
**Motivation**

Currently, the 'hex' option and the 'help' option have clashing shortenings (both begin with 'h').

**Description**

This PR removes the short version of 'hex'.
