### PR TITLE
feat(cli): implement printing only result address in deploy

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -284,6 +284,7 @@ Options:
       --gas-limit <GAS_LIMIT>
       --gas-price <MAX_FEE_PER_GAS>
       --priority-gas-price <MAX_PRIORITY_FEE_PER_GAS>
+      --print-address                                  Only print the contract address
   -b                                                   Do not wait for the transaction receipt
       --explorer-url                                   Display transaction URL in the explorer.
   -h, --help                                           Print help

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -410,8 +410,12 @@ impl Command {
                     )
                     .await?;
 
-                println!("Contract deployed in tx: {tx_hash:#x}");
-                println!("Contract address: {deployed_contract_address:#x}");
+                if args.print_address {
+                    println!("{deployed_contract_address:#x}");
+                } else {
+                    println!("Contract deployed in tx: {tx_hash:#x}");
+                    println!("Contract address: {deployed_contract_address:#x}");
+                }
 
                 if !args.cast {
                     wait_for_transaction_receipt(tx_hash, &client, 100).await?;

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -135,6 +135,8 @@ pub struct DeployArgs {
     pub max_fee_per_gas: Option<u64>,
     #[clap(long = "priority-gas-price", required = false)]
     pub max_priority_fee_per_gas: Option<u64>,
+    #[clap(long = "print-address", required = false)]
+    pub print_address: bool,
     #[clap(
         short = 'b',
         required = false,

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -135,7 +135,7 @@ pub struct DeployArgs {
     pub max_fee_per_gas: Option<u64>,
     #[clap(long = "priority-gas-price", required = false)]
     pub max_priority_fee_per_gas: Option<u64>,
-    #[clap(long = "print-address", required = false)]
+    #[clap(long, required = false)]
     pub print_address: bool,
     #[clap(
         short = 'b',


### PR DESCRIPTION
**Motivation**

When using rex in scripts, it can be convenient to only print the address of a deployed contract.

**Description**

This adds a flag to only print the address.

