### PR TITLE
feat(cli): make receipt wait silent if needed

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -431,7 +431,7 @@ impl Command {
                     println!("Contract address: {deployed_contract_address:#x}");
                 }
                 let silent = args.print_address;
-                
+
                 if !args.cast {
                     wait_for_transaction_receipt(tx_hash, &client, 100, silent).await?;
                 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -315,7 +315,7 @@ impl Command {
                 println!("{tx_hash:#x}");
 
                 if !args.cast {
-                    wait_for_transaction_receipt(tx_hash, &client, 100).await?;
+                    wait_for_transaction_receipt(tx_hash, &client, 100, false).await?;
                 }
             }
             Command::Send { args, rpc_url } => {
@@ -359,7 +359,7 @@ impl Command {
                 println!("{tx_hash:#x}",);
 
                 if !args.cast {
-                    wait_for_transaction_receipt(tx_hash, &client, 100).await?;
+                    wait_for_transaction_receipt(tx_hash, &client, 100, false).await?;
                 }
             }
             Command::Call { args, rpc_url } => {
@@ -430,9 +430,10 @@ impl Command {
                     println!("Contract deployed in tx: {tx_hash:#x}");
                     println!("Contract address: {deployed_contract_address:#x}");
                 }
-
+                let silent = args.print_address;
+                
                 if !args.cast {
-                    wait_for_transaction_receipt(tx_hash, &client, 100).await?;
+                    wait_for_transaction_receipt(tx_hash, &client, 100, silent).await?;
                 }
             }
             Command::ChainId { hex, rpc_url } => {

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -265,7 +265,7 @@ impl Command {
                 println!("Deposit sent: {tx_hash:#x}");
 
                 if !cast {
-                    wait_for_transaction_receipt(tx_hash, &eth_client, 100).await?;
+                    wait_for_transaction_receipt(tx_hash, &eth_client, 100, false).await?;
                 }
             }
             Command::ClaimWithdraw {
@@ -296,7 +296,7 @@ impl Command {
                 println!("Withdrawal claim sent: {tx_hash:#x}");
 
                 if !cast {
-                    wait_for_transaction_receipt(tx_hash, &eth_client, 100).await?;
+                    wait_for_transaction_receipt(tx_hash, &eth_client, 100, false).await?;
                 }
             }
             Command::Withdraw {
@@ -325,7 +325,7 @@ impl Command {
                 println!("Withdrawal sent: {tx_hash:#x}");
 
                 if !cast {
-                    wait_for_transaction_receipt(tx_hash, &client, 100).await?;
+                    wait_for_transaction_receipt(tx_hash, &client, 100, false).await?;
                 }
             }
             Command::WithdrawalProof {

--- a/sdk/examples/simple_usage.rs
+++ b/sdk/examples/simple_usage.rs
@@ -66,7 +66,7 @@ async fn main() {
     .unwrap();
 
     // Wait for the transaction to be finalized
-    wait_for_transaction_receipt(tx_hash, &eth_client, 100)
+    wait_for_transaction_receipt(tx_hash, &eth_client, 100, false)
         .await
         .unwrap();
 

--- a/sdk/src/client/eth/eth_sender.rs
+++ b/sdk/src/client/eth/eth_sender.rs
@@ -100,9 +100,6 @@ impl EthClient {
                 EthClientError::Custom("Failed to get deployed_address".to_owned()),
             )?);
 
-        self.wait_for_transaction_receipt(deploy_tx_hash, 1000)
-            .await?;
-
         Ok((deploy_tx_hash, deployed_address))
     }
 }

--- a/sdk/src/sdk.rs
+++ b/sdk/src/sdk.rs
@@ -34,7 +34,7 @@ pub async fn wait_for_transaction_receipt(
     tx_hash: H256,
     client: &EthClient,
     max_retries: u64,
-    silent: bool
+    silent: bool,
 ) -> Result<RpcReceipt, EthClientError> {
     let mut receipt = client.get_transaction_receipt(tx_hash).await?;
     let mut r#try = 1;

--- a/sdk/src/sdk.rs
+++ b/sdk/src/sdk.rs
@@ -34,11 +34,14 @@ pub async fn wait_for_transaction_receipt(
     tx_hash: H256,
     client: &EthClient,
     max_retries: u64,
+    silent: bool
 ) -> Result<RpcReceipt, EthClientError> {
     let mut receipt = client.get_transaction_receipt(tx_hash).await?;
     let mut r#try = 1;
     while receipt.is_none() {
-        println!("[{try}/{max_retries}] Retrying to get transaction receipt for {tx_hash:#x}");
+        if !silent {
+            println!("[{try}/{max_retries}] Retrying to get transaction receipt for {tx_hash:#x}");
+        }
 
         if max_retries == r#try {
             return Err(EthClientError::Custom(format!(


### PR DESCRIPTION
**Motivation**

If the output is to be used in scripts, it should not have unneeded output.

**Description**

Silences the transaction wait if the print-address flag is set.

Also removes a duplicate wait on deploy.
