### PR TITLE
feat(cli): command verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,19 @@ Commands:
   autocomplete  Generate shell completion scripts.
   balance       Get the account's balance info. [aliases: bal, b]
   block-number  Get the current block_number. [aliases: bl]
-  call          Make a call to a contract
+  call          Make a call to a contract.
   chain-id      Get the network's chain id.
-  deploy        Deploy a contract
-  code          Returns code at a given address
-  hash          Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h, h]
+  deploy        Deploy a contract.
+  code          Returns code at a given address.
+  hash          Get either the keccak for a given input, the zero hash, the empty string, or a random hash. [aliases: h, h]
   l2            L2 specific commands.
   nonce         Get the account's nonce. [aliases: n]
   receipt       Get the transaction's receipt. [aliases: r]
-  send          Send a transaction
+  send          Send a transaction.
   signer        
   transaction   Get the transaction's info. [aliases: tx, t]
   transfer      Transfer funds to another wallet.
+  verify        Verify if a messages signature was made by an account.
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -278,7 +278,7 @@ impl Command {
             Command::Signer { message, signature } => {
                 let signer = get_address_from_message_and_signature(message, signature)?;
 
-                println!("{signer:x}");
+                println!("{signer:x?}");
             }
             Command::Transfer { args, rpc_url } => {
                 if args.token_address.is_some() {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -175,7 +175,7 @@ pub(crate) enum Command {
         rpc_url: String,
     },
     #[clap(about = "Verify if the signature of a message was made by an account")]
-    Verify {
+    VerifySignature {
         #[arg(value_parser = parse_hex)]
         message: Bytes,
         #[arg(value_parser = parse_hex)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -278,7 +278,7 @@ impl Command {
             Command::Signer { message, signature } => {
                 let signer = get_address_from_message_and_signature(message, signature)?;
 
-                println!("{signer}");
+                println!("{signer:x}");
             }
             Command::Transfer { args, rpc_url } => {
                 if args.token_address.is_some() {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -478,7 +478,7 @@ impl Command {
 
                 println!("0x{:x}", H520::from_slice(&encoded_signature));
             }
-            Command::Verify {
+            Command::VerifySignature {
                 message,
                 signature,
                 address,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,20 +1,10 @@
-use ethrex_common::{Bytes, H256, U256};
+use ethrex_common::{Bytes, U256};
 use hex::FromHexError;
 use secp256k1::SecretKey;
 use std::str::FromStr;
 
 pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
     Ok(SecretKey::from_slice(&parse_hex(s)?)?)
-}
-
-pub fn parse_message(s: &str) -> eyre::Result<secp256k1::Message> {
-    let parsed = secp256k1::Message::from_digest(*parse_h256(s)?.as_fixed_bytes());
-    Ok(parsed)
-}
-
-pub fn parse_h256(s: &str) -> eyre::Result<H256> {
-    let parsed = H256::from_slice(&parse_hex(s)?);
-    Ok(parsed)
 }
 
 pub fn parse_u256(s: &str) -> eyre::Result<U256> {

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -21,7 +21,7 @@ use ethrex_rpc::{
 };
 use keccak_hash::keccak;
 use reqwest::Client;
-use secp256k1::SecretKey;
+use secp256k1::{Error, SecretKey};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::ops::Div;
@@ -1140,6 +1140,37 @@ pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, Et
         })?;
 
     Ok(Address::from(address_bytes))
+}
+
+pub fn get_address_from_message_and_signature(
+    message: Bytes,
+    signature: Bytes,
+) -> Result<Address, Error> {
+    let raw_recovery_id = if signature[64] >= 27 {
+        signature[64] - 27
+    } else {
+        signature[64]
+    };
+
+    let recovery_id = secp256k1::ecdsa::RecoveryId::from_i32(raw_recovery_id as i32)?;
+
+    let signature =
+        secp256k1::ecdsa::RecoverableSignature::from_compact(&signature[..64], recovery_id)?;
+
+    let payload = [
+        b"\x19Ethereum Signed Message:\n",
+        message.len().to_string().as_bytes(),
+        message.as_ref(),
+    ]
+    .concat();
+
+    let signer_public_key = signature.recover(&secp256k1::Message::from_digest(
+        *keccak(payload).as_fixed_bytes(),
+    ))?;
+
+    Ok(Address::from_slice(
+        &keccak(&signer_public_key.serialize_uncompressed()[1..])[12..],
+    ))
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -1142,6 +1142,9 @@ pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, Et
     Ok(Address::from(address_bytes))
 }
 
+// This function takes signatures that are computed as a 0x45 signature, as described in EIP-191 (https://eips.ethereum.org/EIPS/eip-191),
+// then it has an extra byte concatenated at the end, which is a scalar value added to the signatures parity,
+// as described in the Yellow Paper Section 4.2 in the specification of a transaction's w field. (https://ethereum.github.io/yellowpaper/paper.pdf)
 pub fn get_address_from_message_and_signature(
     message: Bytes,
     signature: Bytes,


### PR DESCRIPTION
**Motivation**

Expand CLI commands: implementation of the verify command

**Description**

Implementation of the command verify for rex that given a message in bytes that will be passed as a hex string (with or without the 0x prefix), a signature (also a hex string) and an account's address (also a hex string), verifies if the signature was made by said account by printing true or false. 

**How to test**

To test the command you should use it like this:

```
rex verify <MESSAGE> <SIGNATURE> <ADDRESS>
```

> [!IMPORTANT]
> To use `rex sign` you need #103 and to use `rex signer` you need #107.

```Shell
// 1. Sign a message using a private key.
rex sign 0x779172e004a01f01249038ed576516345ee9ce46a5e678b61945f33eff7448bb 0x052d7e212b30b505f337b0be5cf953c3d3175724f337b0be5cf953c3d3175724

// 2. Retrieve the signer.
rex signer 0x779172e004a01f01249038ed576516345ee9ce46a5e678b61945f33eff7448bb 0x59fa0ee54bc49b8130b465a2b378674ad70675e608407d30fe0289c800889b81167eb8e34007c5afbc845866d809583939f3a25dbae1c81ff6bf6959827b91ad1c

// 3. Confirm that the signer corresponds to the address associated to the private key used before.
rex verify 0x779172e004a01f01249038ed576516345ee9ce46a5e678b61945f33eff7448bb 0x59fa0ee54bc49b8130b465a2b378674ad70675e608407d30fe0289c800889b81167eb8e34007c5afbc845866d809583939f3a25dbae1c81ff6bf6959827b91ad1c 0x559778627fbe1591d72971915ec91fb8eb55bbc9
```

Closes #113 

