### PR TITLE
feat(sdk): implement calldata decoding

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -291,6 +291,32 @@ Options:
   -h, --help                                           Print help
 ```
 
+### `rex encode-calldata`
+
+```Shell
+Usage: rex encode-calldata <SIGNATURE> [ARGUMENTS]
+
+Arguments:
+  <SIGNATURE>
+  [SIGNATURE]
+
+Options:
+  -h, --help  Print help
+```
+
+### `rex decode-calldata`
+
+```Shell
+Usage: rex decode-calldata <SIGNATURE> <CALLDATA>
+
+Arguments:
+  <SIGNATURE>
+  <CALLDATA>
+
+Options:
+  -h, --help  Print help
+```
+
 ## Examples
 
 A curated list of examples as GIFs.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -8,6 +8,7 @@ use crate::{
 use clap::{ArgAction, Parser, Subcommand};
 use ethrex_common::{Address, Bytes, H256, H520};
 use keccak_hash::keccak;
+use rex_sdk::calldata::{Value, decode_calldata};
 use rex_sdk::{
     balance_in_eth,
     client::{
@@ -181,6 +182,18 @@ pub(crate) enum Command {
         #[arg(value_parser = parse_hex)]
         signature: Bytes,
         address: Address,
+    },
+    #[clap(about = "Encodes calldata")]
+    EncodeCalldata {
+        signature: String,
+        #[arg(last = true)]
+        args: Vec<String>,
+    },
+    #[clap(about = "Decodes calldata")]
+    DecodeCalldata {
+        signature: String,
+        #[arg(value_parser = parse_hex)]
+        data: Bytes,
     },
 }
 
@@ -395,7 +408,7 @@ impl Command {
 
                 let client = EthClient::new(&rpc_url);
 
-                let init_code = if args._args.len() > 0 {
+                let init_code = if !args._args.is_empty() {
                     let init_args = parse_contract_creation(args._args)?;
                     [args.bytecode, init_args].concat().into()
                 } else {
@@ -489,7 +502,53 @@ impl Command {
                     get_address_from_message_and_signature(message, signature)? == address
                 );
             }
+            Command::EncodeCalldata {
+                signature,
+                mut args,
+            } => {
+                args.insert(0, signature);
+                println!("0x{:x}", parse_func_call(args)?);
+            }
+            Command::DecodeCalldata { signature, data } => {
+                for elem in decode_calldata(&signature, data)? {
+                    print_calldata(0, elem);
+                }
+            }
         };
         Ok(())
+    }
+}
+
+fn print_calldata(depth: usize, data: Value) {
+    print!("{}", " ".repeat(depth));
+    match data {
+        Value::Address(addr) => println!("{addr:#x}"),
+        Value::Array(inner) => {
+            println!("[");
+            for elem in inner {
+                print_calldata(depth + 2, elem);
+            }
+            println!("]");
+        }
+        Value::Bool(b) => println!("{b}"),
+        Value::Bytes(bytes) => println!("0x{bytes:#x}"),
+        Value::FixedArray(inner) => {
+            println!("[");
+            for elem in inner {
+                print_calldata(depth + 2, elem);
+            }
+            println!("]");
+        }
+        Value::FixedBytes(bytes) => println!("{bytes:#x}"),
+        Value::Int(val) => println!("{val}"),
+        Value::Uint(val) => println!("{val}"),
+        Value::String(str) => println!("{str}"),
+        Value::Tuple(inner) => {
+            println!("(");
+            for elem in inner {
+                print_calldata(depth + 2, elem);
+            }
+            println!(")");
+        }
     }
 }

--- a/sdk/src/calldata.rs
+++ b/sdk/src/calldata.rs
@@ -28,6 +28,16 @@ pub enum Value {
     FixedBytes(Bytes),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum CalldataDecodeError {
+    #[error("Failed to parse function signature: {0}")]
+    ParseError(String),
+    #[error("Invalid calldata. Tried to read more bytes than there are.")]
+    OutOfBounds,
+    #[error("Internal Calldata decoding error. This is most likely a bug")]
+    InternalError,
+}
+
 pub fn parse_signature(signature: &str) -> Result<(String, Vec<String>), CalldataEncodeError> {
     let sig = signature.trim().trim_start_matches("function ");
     let (name, params) = sig
@@ -102,6 +112,191 @@ pub fn encode_calldata(signature: &str, values: &[Value]) -> Result<Vec<u8>, Cal
     with_selector.extend_from_slice(&calldata);
 
     Ok(with_selector)
+}
+
+pub fn decode_calldata(signature: &str, data: Bytes) -> Result<Vec<Value>, CalldataDecodeError> {
+    let (_, params) =
+        parse_signature(signature).map_err(|e| CalldataDecodeError::ParseError(e.to_string()))?;
+    let mut decoder = DecodeHelper::new(&data);
+    let datatype = DataType::Tuple(
+        params
+            .iter()
+            .map(|v| DataType::parse(v))
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+    match datatype.decode(&mut decoder)? {
+        Value::Tuple(values) => Ok(values),
+        _ => Err(CalldataDecodeError::InternalError),
+    }
+}
+
+struct DecodeHelper<'a> {
+    buf: &'a [u8],
+    index: usize,
+}
+
+impl<'a> DecodeHelper<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        DecodeHelper { buf, index: 4 }
+    }
+    fn consume(&mut self, n: usize) -> Result<&'a [u8], CalldataDecodeError> {
+        let data = self
+            .buf
+            .get(self.index..self.index + n)
+            .ok_or(CalldataDecodeError::OutOfBounds)?;
+        self.index += n;
+        Ok(data)
+    }
+    fn consume_u256(&mut self) -> Result<U256, CalldataDecodeError> {
+        Ok(U256::from_big_endian(self.consume(32)?))
+    }
+    fn start_reading_at(&self, offset: usize) -> Result<Self, CalldataDecodeError> {
+        let data = self
+            .buf
+            .get(self.index + offset..)
+            .ok_or(CalldataDecodeError::OutOfBounds)?;
+        Ok(DecodeHelper {
+            buf: data,
+            index: 0,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+enum DataType {
+    Array(Box<DataType>),
+    FixedArray(usize, Box<DataType>),
+    Tuple(Vec<DataType>),
+    Bytes,
+    FixedBytes(usize),
+    Address,
+    Bool,
+    Uint,
+    Int,
+}
+
+impl DataType {
+    fn parse(param: &str) -> Result<Self, CalldataDecodeError> {
+        Ok(match param {
+            _ if param.ends_with("[]") => {
+                let inner = param
+                    .strip_suffix("[]")
+                    .ok_or(CalldataDecodeError::InternalError)?;
+                DataType::Array(Box::new(DataType::parse(inner)?))
+            }
+            _ if param.ends_with("]") => {
+                let mut n = String::new();
+                let mut iter = param.chars().rev().skip(1);
+                for c in iter.by_ref() {
+                    if c.is_ascii_digit() {
+                        n.insert(0, c);
+                    } else {
+                        break;
+                    }
+                }
+                iter.next();
+                let inner: String = iter.collect::<String>().chars().rev().collect();
+                let n: usize = n.parse().map_err(|_| CalldataDecodeError::OutOfBounds)?;
+                DataType::FixedArray(n, Box::new(DataType::parse(&inner)?))
+            }
+            _ if param.ends_with(")") => {
+                let (_, inner) = parse_signature(param)
+                    .map_err(|e| CalldataDecodeError::ParseError(e.to_string()))?;
+                DataType::Tuple(
+                    inner
+                        .iter()
+                        .map(|v| DataType::parse(v))
+                        .collect::<Result<Vec<_>, _>>()?,
+                )
+            }
+            "address" => DataType::Address,
+            "bool" => DataType::Bool,
+            "bytes" => DataType::Bytes,
+            _ if param.starts_with("bytes") => {
+                let n = param
+                    .trim_start_matches("bytes")
+                    .parse()
+                    .map_err(|_| CalldataDecodeError::ParseError("invalid bytesN".to_string()))?;
+                DataType::FixedBytes(n)
+            }
+            _ if param.starts_with("uint") => DataType::Uint,
+            _ if param.starts_with("int") => DataType::Int,
+            _ => {
+                return Err(CalldataDecodeError::ParseError(format!(
+                    "unknown type {param}"
+                )));
+            }
+        })
+    }
+    fn is_dynamic(&self) -> bool {
+        match self {
+            DataType::Array(_) => true,
+            DataType::Bytes => true,
+            DataType::FixedArray(_, inner) => inner.is_dynamic(),
+            DataType::Tuple(inner) => inner.iter().any(|t| t.is_dynamic()),
+            _ => false,
+        }
+    }
+    fn decode(&self, data: &mut DecodeHelper) -> Result<Value, CalldataDecodeError> {
+        Ok(match self {
+            DataType::Uint => Value::Uint(data.consume_u256()?),
+            DataType::Int => Value::Int(data.consume_u256()?),
+            DataType::Address => {
+                data.consume(32 - 20)?;
+                Value::Address(Address::from_slice(data.consume(20)?))
+            }
+            DataType::Bool => Value::Bool(!data.consume_u256()?.is_zero()),
+            DataType::FixedBytes(n) => Value::FixedBytes(data.consume(32)?[0..*n].to_vec().into()),
+            DataType::Bytes => {
+                let n: usize = data
+                    .consume_u256()?
+                    .try_into()
+                    .map_err(|_| CalldataDecodeError::OutOfBounds)?;
+                let size = if n % 32 == 0 {
+                    n
+                } else {
+                    n.next_multiple_of(32)
+                };
+                Value::Bytes(data.consume(size)?[0..n].to_vec().into())
+            }
+            DataType::FixedArray(n, inner_type) => {
+                let inner_type = *inner_type.clone();
+                let value = DataType::Tuple(vec![inner_type; *n]).decode(data)?;
+                match value {
+                    Value::Tuple(inner) => Value::FixedArray(inner),
+                    _ => return Err(CalldataDecodeError::InternalError),
+                }
+            }
+            DataType::Tuple(inner_types) => {
+                let mut values = Vec::new();
+                let start_reader = data.start_reading_at(0)?;
+                for inner_type in inner_types {
+                    if inner_type.is_dynamic() {
+                        let offset: usize = data
+                            .consume_u256()?
+                            .try_into()
+                            .map_err(|_| CalldataDecodeError::OutOfBounds)?;
+                        values
+                            .push(inner_type.decode(&mut start_reader.start_reading_at(offset)?)?);
+                    } else {
+                        values.push(inner_type.decode(data)?);
+                    }
+                }
+                Value::Tuple(values)
+            }
+            DataType::Array(inner_type) => {
+                let n: usize = data
+                    .consume_u256()?
+                    .try_into()
+                    .map_err(|_| CalldataDecodeError::OutOfBounds)?;
+                let mut values = Vec::new();
+                for _ in 0..n {
+                    values.push(inner_type.decode(data)?);
+                }
+                Value::Array(values)
+            }
+        })
+    }
 }
 
 // This is the main entrypoint for ABI encoding solidity function arguments, as the list of arguments themselves are
@@ -328,6 +523,8 @@ fn calldata_test() {
 
     let calldata = encode_calldata(raw_function_signature, &arguments).unwrap();
 
+    let decoded = decode_calldata(raw_function_signature, calldata.clone().into()).unwrap();
+    assert_eq!(arguments, decoded);
     assert_eq!(
         calldata,
         vec![
@@ -365,6 +562,8 @@ fn encode_tuple_dynamic_offset() {
     let values = vec![tuple];
 
     let calldata = encode_calldata(raw_function_signature, &values).unwrap();
+    let decoded = decode_calldata(raw_function_signature, calldata.clone().into()).unwrap();
+    assert_eq!(values, decoded);
 
     assert_eq!(calldata, hex::decode("02e86bbe0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000006793200000000000000000000000000000000000000000000000000000000000679320000000000000000000000000000000000000000000000000000000000019a2800000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000").unwrap());
 
@@ -402,6 +601,8 @@ fn correct_tuple_parsing() {
 fn empty_calldata() {
     let calldata = encode_calldata("number()", &[]).unwrap();
     assert_eq!(calldata, hex::decode("8381f58a").unwrap());
+    let decoded = decode_calldata("number()", calldata.clone().into()).unwrap();
+    assert!(decoded.is_empty());
 }
 
 #[test]
@@ -413,4 +614,6 @@ fn bytes_has_padding() {
     let calldata = encode_calldata(raw_function_signature, &values).unwrap();
 
     assert_eq!(calldata, hex::decode("f570899b0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b68656c6c6f20776f726c64000000000000000000000000000000000000000000").unwrap());
+    let decoded = decode_calldata(raw_function_signature, calldata.clone().into()).unwrap();
+    assert_eq!(values, decoded);
 }


### PR DESCRIPTION
**Motivation**

It's useful to be able to decode calldata for debugging. This functionality is also useful for the ethrex CLI.

**Description**

Implements calldata decoding and makes use of relevant existing tests. A decode-calldata command is impemented for ease of testing.

For symmetry, a a encode-calldata command is also implemented since the logic already exists.
