### PR TITLE
feat(sdk): add keystores support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,6 +1448,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac 0.12.1",
+ "pbkdf2",
+ "rand",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "ethbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,6 +3307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,6 +3807,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "envy",
+ "eth-keystore",
  "ethrex-blockchain",
  "ethrex-common",
  "ethrex-l2",
@@ -3786,7 +3818,9 @@ dependencies = [
  "itertools 0.14.0",
  "jsonwebtoken",
  "keccak-hash",
+ "lazy_static",
  "log",
+ "rand",
  "reqwest",
  "secp256k1",
  "serde",
@@ -3996,6 +4030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,6 +4061,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "sec1"
@@ -4977,6 +5032,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.15",
+ "serde",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3818,7 +3818,6 @@ dependencies = [
  "itertools 0.14.0",
  "jsonwebtoken",
  "keccak-hash",
- "lazy_static",
  "log",
  "rand",
  "reqwest",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -20,6 +20,8 @@ jsonwebtoken = "9.3.0"
 # Crypto
 keccak-hash.workspace = true
 secp256k1.workspace = true
+eth-keystore = "0.5"
+rand = "0.8.5"
 
 # Utils
 hex.workspace = true
@@ -27,6 +29,7 @@ itertools = "0.14.0"
 toml = "0.8.19"
 dirs = "6.0.0"
 envy = "0.4.2"
+lazy_static = "1.5"
 thiserror.workspace = true
 
 # Logging

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -29,7 +29,6 @@ itertools = "0.14.0"
 toml = "0.8.19"
 dirs = "6.0.0"
 envy = "0.4.2"
-lazy_static = "1.5"
 thiserror.workspace = true
 
 # Logging

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -14,6 +14,6 @@ pub enum KeystoreError {
     ErrorCreatingKeystore(String),
     #[error("Error creating secret key: {0}")]
     ErrorCreatingSecretKey(String),
-    #[error("Error opnening keystore: {0}")]
+    #[error("Error opening keystore: {0}")]
     ErrorOpeningKeystore(String),
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -5,3 +5,9 @@ pub enum Error {
     #[error(transparent)]
     EthClientError(#[from] EthClientError),
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeystoreError {
+    #[error("Error sending request")]
+    Err,
+}

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -10,9 +10,9 @@ pub enum Error {
 pub enum KeystoreError {
     #[error("Error creating default dir: {0}")]
     ErrorCreatingDefaultDir(String),
-    #[error("Error creating Keystore: {0}")]
+    #[error("Error creating keystore: {0}")]
     ErrorCreatingKeystore(String),
-    #[error("Error creating SecretKey: {0}")]
+    #[error("Error creating secret key: {0}")]
     ErrorCreatingSecretKey(String),
     #[error("Error opnening keystore: {0}")]
     ErrorOpeningKeystore(String),

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -8,6 +8,12 @@ pub enum Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum KeystoreError {
-    #[error("Error sending request")]
-    Err,
+    #[error("Error creating default dir: {0}")]
+    ErrorCreatingDefaultDir(String),
+    #[error("Error creating Keystore: {0}")]
+    ErrorCreatingKeystore(String),
+    #[error("Error creating SecretKey: {0}")]
+    ErrorCreatingSecretKey(String),
+    #[error("Error opnening keystore: {0}")]
+    ErrorOpeningKeystore(String),
 }

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -21,7 +21,7 @@ lazy_static! {
 /// Creates a new keystore in the given path and name using the password.
 /// If no path is provided, uses KEYSTORE_DEFAULT_PATH.
 /// If no name is provided, generates a random one.
-/// Returns the SecretKey generated a the UUID of the filesystem.
+/// Returns the SecretKey and the UUID of the keystore file.
 pub fn create_new_keystore<S>(
     path: Option<&str>,
     name: Option<&str>,

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -53,7 +53,7 @@ where
 /// Loads the SecretKey from a given Keystore.
 /// If path is not provided, uses KEYSTORE_DEFAULT_PATH.
 /// Returns the SecretKey loaded.
-pub fn load_keystore<S>(
+pub fn load_keystore_from_path<S>(
     path: Option<&str>,
     name: &str,
     password: S,
@@ -83,7 +83,7 @@ mod tests {
             create_new_keystore(None, Some("RexTest"), "LambdaClass")
                 .unwrap()
                 .0,
-            load_keystore(None, "RexTest", "LambdaClass").unwrap()
+            load_keystore_from_path(None, "RexTest", "LambdaClass").unwrap()
         );
     }
 }

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -60,11 +60,10 @@ where
     S: AsRef<[u8]>,
 {
     let keystore_default_path = get_keystore_default_path();
-    let path = match path {
-        Some(p) => Path::new(p).join(name),
+    let path = path
+        .map_or(Path::new(keystore_default_path.as_str()), Path::new)
+        .join(name);
 
-        None => Path::new(keystore_default_path.as_str()).join(name),
-    };
     let key_vec = decrypt_key(path, password)
         .map_err(|e| KeystoreError::ErrorOpeningKeystore(e.to_string()))?;
     let secret_key = SecretKey::from_slice(&key_vec)

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -3,6 +3,7 @@ use dirs::data_dir;
 use eth_keystore::{decrypt_key, new as eth_keystore_new};
 use lazy_static::lazy_static;
 use rand::rngs::OsRng;
+use secp256k1::SecretKey;
 use std::fs;
 use std::path::Path;
 
@@ -17,11 +18,15 @@ lazy_static! {
     };
 }
 
+/// creates a new keystore in the given path and name using the password
+/// if no path is provided, uses KEYSTORE_DEFAULT_PATH
+/// if no name is provided, generates a random one
+/// returns the SecretKey generated a the UUID of the filesystem
 pub fn create_new_keystore<S>(
     path: Option<&str>,
     name: Option<&str>,
     password: S,
-) -> Result<(Vec<u8>, String), KeystoreError>
+) -> Result<(SecretKey, String), KeystoreError>
 where
     S: AsRef<[u8]>,
 {
@@ -31,20 +36,28 @@ where
             // check if default path exists or create it
             let p = Path::new(KEYSTORE_DEFAULT_PATH.as_str());
             if !p.exists() {
-                fs::create_dir_all(KEYSTORE_DEFAULT_PATH.as_str()).unwrap();
+                fs::create_dir_all(KEYSTORE_DEFAULT_PATH.as_str())
+                    .map_err(|e| KeystoreError::ErrorCreatingDefaultDir(e.to_string()))?;
             }
             p
         }
     };
     let mut rng = OsRng;
-    Ok(eth_keystore_new(path, &mut rng, password, name).unwrap())
+    let (key_vec, uuid) = eth_keystore_new(path, &mut rng, password, name)
+        .map_err(|e| KeystoreError::ErrorCreatingKeystore(e.to_string()))?;
+    let secret_key = SecretKey::from_slice(&key_vec)
+        .map_err(|e| KeystoreError::ErrorCreatingSecretKey(e.to_string()))?;
+    Ok((secret_key, uuid))
 }
 
+/// loads the SecretKey from a given Keystore
+/// if path is not provided, uses KEYSTORE_DEFAULT_PATH
+/// returns the SecretKey loaded
 pub fn load_keystore<S>(
     path: Option<&str>,
     name: &str,
     password: S,
-) -> Result<Vec<u8>, KeystoreError>
+) -> Result<SecretKey, KeystoreError>
 where
     S: AsRef<[u8]>,
 {
@@ -53,7 +66,11 @@ where
 
         None => Path::new(KEYSTORE_DEFAULT_PATH.as_str()).join(name),
     };
-    Ok(decrypt_key(path, password).unwrap())
+    let key_vec = decrypt_key(path, password)
+        .map_err(|e| KeystoreError::ErrorOpeningKeystore(e.to_string()))?;
+    let secret_key = SecretKey::from_slice(&key_vec)
+        .map_err(|e| KeystoreError::ErrorCreatingSecretKey(e.to_string()))?;
+    Ok(secret_key)
 }
 
 #[cfg(test)]
@@ -63,8 +80,10 @@ mod tests {
     #[test]
     pub fn test_create_and_load_keystore() {
         assert_eq!(
-            create_new_keystore(None, Some("Test"), "REX").unwrap().0,
-            load_keystore(None, "Test", "REX").unwrap()
+            create_new_keystore(None, Some("RexTest"), "LambdaClass")
+                .unwrap()
+                .0,
+            load_keystore(None, "RexTest", "LambdaClass").unwrap()
         );
     }
 }

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -18,10 +18,10 @@ lazy_static! {
     };
 }
 
-/// creates a new keystore in the given path and name using the password
-/// if no path is provided, uses KEYSTORE_DEFAULT_PATH
-/// if no name is provided, generates a random one
-/// returns the SecretKey generated a the UUID of the filesystem
+/// creates a new keystore in the given path and name using the password.
+/// if no path is provided, uses KEYSTORE_DEFAULT_PATH.
+/// if no name is provided, generates a random one.
+/// returns the SecretKey generated a the UUID of the filesystem.
 pub fn create_new_keystore<S>(
     path: Option<&str>,
     name: Option<&str>,
@@ -50,9 +50,9 @@ where
     Ok((secret_key, uuid))
 }
 
-/// loads the SecretKey from a given Keystore
-/// if path is not provided, uses KEYSTORE_DEFAULT_PATH
-/// returns the SecretKey loaded
+/// loads the SecretKey from a given Keystore.
+/// if path is not provided, uses KEYSTORE_DEFAULT_PATH.
+/// returns the SecretKey loaded.
 pub fn load_keystore<S>(
     path: Option<&str>,
     name: &str,

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -18,10 +18,10 @@ lazy_static! {
     };
 }
 
-/// creates a new keystore in the given path and name using the password.
-/// if no path is provided, uses KEYSTORE_DEFAULT_PATH.
-/// if no name is provided, generates a random one.
-/// returns the SecretKey generated a the UUID of the filesystem.
+/// Creates a new keystore in the given path and name using the password.
+/// If no path is provided, uses KEYSTORE_DEFAULT_PATH.
+/// If no name is provided, generates a random one.
+/// Returns the SecretKey generated a the UUID of the filesystem.
 pub fn create_new_keystore<S>(
     path: Option<&str>,
     name: Option<&str>,
@@ -50,9 +50,9 @@ where
     Ok((secret_key, uuid))
 }
 
-/// loads the SecretKey from a given Keystore.
-/// if path is not provided, uses KEYSTORE_DEFAULT_PATH.
-/// returns the SecretKey loaded.
+/// Loads the SecretKey from a given Keystore.
+/// If path is not provided, uses KEYSTORE_DEFAULT_PATH.
+/// Returns the SecretKey loaded.
 pub fn load_keystore<S>(
     path: Option<&str>,
     name: &str,

--- a/sdk/src/keystore.rs
+++ b/sdk/src/keystore.rs
@@ -1,0 +1,70 @@
+use crate::errors::KeystoreError;
+use dirs::data_dir;
+use eth_keystore::{decrypt_key, new as eth_keystore_new};
+use lazy_static::lazy_static;
+use rand::rngs::OsRng;
+use std::fs;
+use std::path::Path;
+
+lazy_static! {
+    pub static ref KEYSTORE_DEFAULT_PATH: String = {
+        let data_dir = data_dir().expect("Failed to get base directories");
+        data_dir
+            .join("rex/keystores/")
+            .to_str()
+            .expect("Failed to convert path to string")
+            .to_owned()
+    };
+}
+
+pub fn create_new_keystore<S>(
+    path: Option<&str>,
+    name: Option<&str>,
+    password: S,
+) -> Result<(Vec<u8>, String), KeystoreError>
+where
+    S: AsRef<[u8]>,
+{
+    let path = match path {
+        Some(p) => Path::new(p),
+        None => {
+            // check if default path exists or create it
+            let p = Path::new(KEYSTORE_DEFAULT_PATH.as_str());
+            if !p.exists() {
+                fs::create_dir_all(KEYSTORE_DEFAULT_PATH.as_str()).unwrap();
+            }
+            p
+        }
+    };
+    let mut rng = OsRng;
+    Ok(eth_keystore_new(path, &mut rng, password, name).unwrap())
+}
+
+pub fn load_keystore<S>(
+    path: Option<&str>,
+    name: &str,
+    password: S,
+) -> Result<Vec<u8>, KeystoreError>
+where
+    S: AsRef<[u8]>,
+{
+    let path = match path {
+        Some(p) => Path::new(p).join(name),
+
+        None => Path::new(KEYSTORE_DEFAULT_PATH.as_str()).join(name),
+    };
+    Ok(decrypt_key(path, password).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_create_and_load_keystore() {
+        assert_eq!(
+            create_new_keystore(None, Some("Test"), "REX").unwrap().0,
+            load_keystore(None, "Test", "REX").unwrap()
+        );
+    }
+}

--- a/sdk/src/sdk.rs
+++ b/sdk/src/sdk.rs
@@ -7,6 +7,7 @@ pub mod calldata;
 pub mod client;
 pub mod create;
 pub mod errors;
+pub mod keystore;
 pub mod utils;
 
 pub mod l2;


### PR DESCRIPTION
**Description**

Added a keystore implementation using this [crate](https://crates.io/crates/eth-keystore).

Used a default folder in the data directory when no path is provided
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #139

