### PR TITLE
fix(cli, sdk): `rex l2 claim-withdraw`

### DIFF
--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -345,7 +345,7 @@ impl Command {
 
                 let from = get_address_from_secret_key(&private_key)?;
 
-                let client = EthClient::new(&rpc_url);
+                let client = EthClient::new(&rpc_url)?;
 
                 let tx_hash = withdraw(amount, from, private_key, &client, nonce).await?;
 
@@ -359,7 +359,7 @@ impl Command {
                 l2_withdrawal_tx_hash,
                 rpc_url,
             } => {
-                let client = EthClient::new(&rpc_url);
+                let client = EthClient::new(&rpc_url)?;
 
                 let (_index, path) =
                     get_withdraw_merkle_proof(&client, l2_withdrawal_tx_hash).await?;

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -62,6 +62,8 @@ pub(crate) enum Command {
     },
     #[clap(about = "Finalize a pending withdrawal.")]
     ClaimWithdraw {
+        #[clap(value_parser = parse_u256)]
+        claimed_amount: U256,
         l2_withdrawal_tx_hash: H256,
         #[clap(
             long,
@@ -275,7 +277,7 @@ impl Command {
 
                 let from = get_address_from_secret_key(&private_key)?;
 
-                let eth_client = EthClient::new(&l1_rpc_url);
+                let eth_client = EthClient::new(&l1_rpc_url)?;
 
                 let tx_hash = deposit(
                     amount,
@@ -294,6 +296,7 @@ impl Command {
                 }
             }
             Command::ClaimWithdraw {
+                claimed_amount,
                 l2_withdrawal_tx_hash,
                 cast,
                 silent,
@@ -304,17 +307,25 @@ impl Command {
             } => {
                 let from = get_address_from_secret_key(&private_key)?;
 
-                let eth_client = EthClient::new(&l1_rpc_url);
+                let eth_client = EthClient::new(&l1_rpc_url)?;
 
-                let client = EthClient::new(&rpc_url);
+                let rollup_client = EthClient::new(&rpc_url)?;
+
+                let message_proof = rollup_client
+                    .wait_for_message_proof(l2_withdrawal_tx_hash, 100)
+                    .await?;
+
+                let withdrawal_proof = message_proof.into_iter().next().ok_or(eyre::eyre!(
+                    "No withdrawal proof found for transaction {l2_withdrawal_tx_hash:#x}"
+                ))?;
 
                 let tx_hash = claim_withdraw(
+                    claimed_amount,
                     l2_withdrawal_tx_hash,
-                    U256::default(), // TODO: Fix this
                     from,
                     private_key,
-                    &client,
                     &eth_client,
+                    &withdrawal_proof,
                     bridge_address,
                 )
                 .await?;

--- a/sdk/examples/simple_usage.rs
+++ b/sdk/examples/simple_usage.rs
@@ -2,7 +2,10 @@ use clap::Parser;
 use ethrex_common::{Address, Bytes, U256};
 use hex::FromHexError;
 use rex_sdk::{
-    client::{EthClient, Overrides, eth::get_address_from_secret_key},
+    client::{
+        EthClient, Overrides,
+        eth::{BlockByNumber, get_address_from_secret_key},
+    },
     transfer, wait_for_transaction_receipt,
 };
 use secp256k1::SecretKey;
@@ -35,11 +38,17 @@ async fn main() {
 
     let rpc_url = "http://localhost:8545";
 
-    let eth_client = EthClient::new(rpc_url);
+    let eth_client = EthClient::new(rpc_url).unwrap();
 
-    let account_balance = eth_client.get_balance(account).await.unwrap();
+    let account_balance = eth_client
+        .get_balance(account, BlockByNumber::Latest)
+        .await
+        .unwrap();
 
-    let account_nonce = eth_client.get_nonce(account).await.unwrap();
+    let account_nonce = eth_client
+        .get_nonce(account, BlockByNumber::Latest)
+        .await
+        .unwrap();
 
     let chain_id = eth_client.get_chain_id().await.unwrap();
 

--- a/sdk/src/client/eth/errors.rs
+++ b/sdk/src/client/eth/errors.rs
@@ -9,7 +9,7 @@ pub enum EthClientError {
     #[error("eth_gasPrice request error: {0}")]
     GetGasPriceError(#[from] GetGasPriceError),
     #[error("eth_estimateGas request error: {0}")]
-    EstimateGasPriceError(#[from] EstimateGasPriceError),
+    EstimateGasError(#[from] EstimateGasError),
     #[error("eth_sendRawTransaction request error: {0}")]
     SendRawTransactionError(#[from] SendRawTransactionError),
     #[error("eth_call request error: {0}")]
@@ -30,16 +30,28 @@ pub enum EthClientError {
     FailedToSerializeRequestBody(String),
     #[error("Failed to deserialize response body: {0}")]
     GetBalanceError(#[from] GetBalanceError),
+    #[error("Failed to deserialize response body: {0}")]
+    GetCodeError(#[from] GetCodeError),
     #[error("eth_getTransactionByHash request error: {0}")]
     GetTransactionByHashError(#[from] GetTransactionByHashError),
+    #[error("ethrex_getMessageProof request error: {0}")]
+    GetMessageProofError(#[from] GetMessageProofError),
+    #[error("eth_maxPriorityFeePerGas request error: {0}")]
+    GetMaxPriorityFeeError(#[from] GetMaxPriorityFeeError),
     #[error("Unreachable nonce")]
     UnrecheableNonce,
     #[error("Error: {0}")]
     Custom(String),
     #[error("Failed to encode calldata: {0}")]
     CalldataEncodeError(#[from] CalldataEncodeError),
-    #[error("secp256k1 error: {0}")]
-    Secp256k1Error(#[from] secp256k1::Error),
+    #[error("Max number of retries reached when trying to send transaction")]
+    TimeoutError,
+    #[error("Internal Error. This is most likely a bug: {0}")]
+    InternalError(String),
+    #[error("Parse Url Error. {0}")]
+    ParseUrlError(String),
+    #[error("Failed to sign payload: {0}")]
+    FailedToSignPayload(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -55,7 +67,7 @@ pub enum GetGasPriceError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum EstimateGasPriceError {
+pub enum EstimateGasError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("{0}")]
@@ -173,6 +185,18 @@ pub enum GetBalanceError {
 }
 
 #[derive(Debug, thiserror::Error)]
+pub enum GetCodeError {
+    #[error("{0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
+    #[error("{0}")]
+    NotHexError(#[from] hex::FromHexError),
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum GetTransactionByHashError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
@@ -192,4 +216,28 @@ pub enum CalldataEncodeError {
     WrongArgumentLength(String),
     #[error("Internal Calldata encoding error. This is most likely a bug")]
     InternalError,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetMessageProofError {
+    #[error("{0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
+    #[error("{0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetMaxPriorityFeeError {
+    #[error("{0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
+    #[error("{0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
 }

--- a/sdk/src/client/eth/eth_sender.rs
+++ b/sdk/src/client/eth/eth_sender.rs
@@ -1,16 +1,17 @@
-use crate::client::eth::{
-    EthClient, RpcResponse,
-    errors::{CallError, EthClientError},
-};
-use ethrex_common::{
-    Address, Bytes, H256, U256,
-    types::{GenericTransaction, TxKind},
-};
+use ethrex_common::types::{GenericTransaction, TxKind};
+use ethrex_common::{Address, U256};
+use ethrex_common::{Bytes, H256};
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_rpc::utils::{RpcRequest, RpcRequestId};
 use keccak_hash::keccak;
 use secp256k1::SecretKey;
 use serde_json::json;
+
+use crate::client::eth::RpcResponse;
+use crate::client::eth::errors::CallError;
+use crate::client::{EthClient, EthClientError};
+
+use super::BlockByNumber;
 
 #[derive(Default, Clone, Debug)]
 pub struct Overrides {
@@ -24,6 +25,7 @@ pub struct Overrides {
     pub max_priority_fee_per_gas: Option<u64>,
     pub access_list: Vec<(Address, Vec<H256>)>,
     pub gas_price_per_blob: Option<U256>,
+    pub block: Option<BlockByNumber>,
 }
 
 impl EthClient {
@@ -39,9 +41,11 @@ impl EthClient {
             value: overrides.value.unwrap_or_default(),
             from: overrides.from.unwrap_or_default(),
             gas: overrides.gas_limit,
-            gas_price: overrides
-                .max_fee_per_gas
-                .unwrap_or(self.get_gas_price().await?.as_u64()),
+            gas_price: if let Some(gas_price) = overrides.max_fee_per_gas {
+                gas_price
+            } else {
+                self.get_gas_price().await?.as_u64()
+            },
             ..Default::default()
         };
 
@@ -59,7 +63,10 @@ impl EthClient {
                     "value": format!("{:#x}", tx.value),
                     "from": format!("{:#x}", tx.from),
                 }),
-                json!("latest"),
+                overrides
+                    .block
+                    .map(Into::into)
+                    .unwrap_or(serde_json::Value::String("latest".to_string())),
             ]),
         };
 
@@ -84,13 +91,13 @@ impl EthClient {
         let mut deploy_overrides = overrides;
         deploy_overrides.to = Some(TxKind::Create);
         let deploy_tx = self
-            .build_eip1559_transaction(Address::zero(), deployer, init_code, deploy_overrides, 10)
+            .build_eip1559_transaction(Address::zero(), deployer, init_code, deploy_overrides)
             .await?;
         let deploy_tx_hash = self
             .send_eip1559_transaction(&deploy_tx, &deployer_private_key)
             .await?;
 
-        let nonce = self.get_nonce(deployer).await?;
+        let nonce = self.get_nonce(deployer, BlockByNumber::Latest).await?;
         let mut encode = vec![];
         (deployer, nonce).encode(&mut encode);
 
@@ -99,6 +106,9 @@ impl EthClient {
             Address::from_slice(keccak(encode).as_fixed_bytes().get(12..).ok_or(
                 EthClientError::Custom("Failed to get deployed_address".to_owned()),
             )?);
+
+        self.wait_for_transaction_receipt(deploy_tx_hash, 1000)
+            .await?;
 
         Ok((deploy_tx_hash, deployed_address))
     }

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -1,7 +1,9 @@
+use std::fmt::{self, Display};
+
 use errors::{
-    EstimateGasPriceError, EthClientError, GetBalanceError, GetBlockByHashError,
-    GetBlockByNumberError, GetBlockNumberError, GetGasPriceError, GetLogsError, GetNonceError,
-    GetTransactionByHashError, GetTransactionReceiptError, SendRawTransactionError,
+    EstimateGasError, EthClientError, GetBalanceError, GetBlockByHashError, GetBlockByNumberError,
+    GetBlockNumberError, GetCodeError, GetGasPriceError, GetLogsError, GetMaxPriorityFeeError,
+    GetNonceError, GetTransactionByHashError, GetTransactionReceiptError, SendRawTransactionError,
 };
 use eth_sender::Overrides;
 use ethrex_common::{
@@ -20,13 +22,11 @@ use ethrex_rpc::{
     utils::{RpcErrorResponse, RpcRequest, RpcRequestId, RpcSuccessResponse},
 };
 use keccak_hash::keccak;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::ops::Div;
-use std::{fmt, time::Duration};
-use tokio::time::{Instant, sleep};
+use std::{ops::Div, str::FromStr};
 use tracing::warn;
 
 pub mod errors;
@@ -42,7 +42,13 @@ pub enum RpcResponse {
 #[derive(Debug, Clone)]
 pub struct EthClient {
     client: Client,
-    pub url: String,
+    pub urls: Vec<Url>,
+    pub max_number_of_retries: u64,
+    pub backoff_factor: u64,
+    pub min_retry_delay: u64,
+    pub max_retry_delay: u64,
+    pub maximum_allowed_max_fee_per_gas: Option<u64>,
+    pub maximum_allowed_max_fee_per_blob_gas: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -52,6 +58,7 @@ pub enum WrappedTransaction {
     L2(PrivilegedL2Transaction),
 }
 
+#[derive(Debug, Clone)]
 pub enum BlockByNumber {
     Number(u64),
     Latest,
@@ -59,22 +66,159 @@ pub enum BlockByNumber {
     Pending,
 }
 
+impl From<BlockByNumber> for Value {
+    fn from(value: BlockByNumber) -> Self {
+        match value {
+            BlockByNumber::Number(n) => json!(format!("{n:#x}")),
+            BlockByNumber::Latest => json!("latest"),
+            BlockByNumber::Earliest => json!("earliest"),
+            BlockByNumber::Pending => json!("pending"),
+        }
+    }
+}
+
+impl From<u64> for BlockByNumber {
+    fn from(value: u64) -> Self {
+        BlockByNumber::Number(value)
+    }
+}
+
+impl Display for BlockByNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockByNumber::Number(n) => write!(f, "{:#x}", n),
+            BlockByNumber::Latest => write!(f, "latest"),
+            BlockByNumber::Earliest => write!(f, "earliest"),
+            BlockByNumber::Pending => write!(f, "pending"),
+        }
+    }
+}
+
+impl TryFrom<&str> for BlockByNumber {
+    type Error = EthClientError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "latest" => Ok(BlockByNumber::Latest),
+            "earliest" => Ok(BlockByNumber::Earliest),
+            "pending" => Ok(BlockByNumber::Pending),
+            _ => value
+                .parse::<u64>()
+                .map(BlockByNumber::from)
+                .map_err(|_| EthClientError::Custom("Invalid block number".to_string())),
+        }
+    }
+}
+
+pub const MAX_NUMBER_OF_RETRIES: u64 = 10;
+pub const BACKOFF_FACTOR: u64 = 2;
+// Give at least 8 blocks before trying to bump gas.
+pub const MIN_RETRY_DELAY: u64 = 96;
+pub const MAX_RETRY_DELAY: u64 = 1800;
+
+const WAIT_TIME_FOR_RECEIPT_SECONDS: u64 = 2;
+
 // 0x08c379a0 == Error(String)
 pub const ERROR_FUNCTION_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
 // 0x70a08231 == balanceOf(address)
 pub const BALANCE_OF_SELECTOR: [u8; 4] = [0x70, 0xa0, 0x82, 0x31];
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct L1MessageProof {
+    pub batch_number: u64,
+    pub index: usize,
+    pub message_hash: H256,
+    pub merkle_proof: Vec<H256>,
+}
+
 impl EthClient {
-    pub fn new(url: &str) -> Self {
-        Self {
+    pub fn new(url: &str) -> Result<EthClient, EthClientError> {
+        Self::new_with_config(
+            vec![url],
+            MAX_NUMBER_OF_RETRIES,
+            BACKOFF_FACTOR,
+            MIN_RETRY_DELAY,
+            MAX_RETRY_DELAY,
+            None,
+            None,
+        )
+    }
+
+    pub fn new_with_config(
+        urls: Vec<&str>,
+        max_number_of_retries: u64,
+        backoff_factor: u64,
+        min_retry_delay: u64,
+        max_retry_delay: u64,
+        maximum_allowed_max_fee_per_gas: Option<u64>,
+        maximum_allowed_max_fee_per_blob_gas: Option<u64>,
+    ) -> Result<Self, EthClientError> {
+        let urls = urls
+            .iter()
+            .map(|url| {
+                Url::parse(url)
+                    .map_err(|_| EthClientError::ParseUrlError("Failed to parse urls".to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
             client: Client::new(),
-            url: url.to_string(),
-        }
+            urls,
+            max_number_of_retries,
+            backoff_factor,
+            min_retry_delay,
+            max_retry_delay,
+            maximum_allowed_max_fee_per_gas,
+            maximum_allowed_max_fee_per_blob_gas,
+        })
+    }
+
+    pub fn new_with_multiple_urls(urls: Vec<String>) -> Result<EthClient, EthClientError> {
+        Self::new_with_config(
+            urls.iter().map(AsRef::as_ref).collect(),
+            MAX_NUMBER_OF_RETRIES,
+            BACKOFF_FACTOR,
+            MIN_RETRY_DELAY,
+            MAX_RETRY_DELAY,
+            None,
+            None,
+        )
     }
 
     async fn send_request(&self, request: RpcRequest) -> Result<RpcResponse, EthClientError> {
+        let mut response = Err(EthClientError::Custom("All rpc calls failed".to_string()));
+
+        for url in self.urls.iter() {
+            response = self.send_request_to_url(url, &request).await;
+            if response.is_ok() {
+                return response;
+            }
+        }
+        response
+    }
+
+    async fn send_request_to_all(
+        &self,
+        request: RpcRequest,
+    ) -> Result<RpcResponse, EthClientError> {
+        let mut response = Err(EthClientError::Custom("All rpc calls failed".to_string()));
+
+        for url in self.urls.iter() {
+            let maybe_response = self.send_request_to_url(url, &request).await;
+            if maybe_response.is_ok() {
+                response = maybe_response;
+            }
+        }
+        response
+    }
+
+    async fn send_request_to_url(
+        &self,
+        rpc_url: &Url,
+        request: &RpcRequest,
+    ) -> Result<RpcResponse, EthClientError> {
         self.client
-            .post(&self.url)
+            .post(rpc_url.as_str())
             .header("content-type", "application/json")
             .body(serde_json::ser::to_string(&request).map_err(|error| {
                 EthClientError::FailedToSerializeRequestBody(format!("{error}: {request:?}"))
@@ -94,7 +238,7 @@ impl EthClient {
             params: Some(vec![json!("0x".to_string() + &hex::encode(data))]),
         };
 
-        match self.send_request(request).await {
+        match self.send_request_to_all(request).await {
             Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
                 .map_err(SendRawTransactionError::SerdeJSONError)
                 .map_err(EthClientError::from),
@@ -110,7 +254,9 @@ impl EthClient {
         tx: &EIP1559Transaction,
         private_key: &SecretKey,
     ) -> Result<H256, EthClientError> {
-        let signed_tx = tx.sign(private_key)?;
+        let signed_tx = tx
+            .sign(private_key)
+            .map_err(|error| EthClientError::FailedToSignPayload(error.to_string()))?;
 
         let mut encoded_tx = signed_tx.encode_to_vec();
         encoded_tx.insert(0, TxType::EIP1559.into());
@@ -124,7 +270,10 @@ impl EthClient {
         private_key: &SecretKey,
     ) -> Result<H256, EthClientError> {
         let mut wrapped_tx = wrapped_tx.clone();
-        wrapped_tx.tx.sign_inplace(private_key)?;
+        wrapped_tx
+            .tx
+            .sign_inplace(private_key)
+            .map_err(|error| EthClientError::FailedToSignPayload(error.to_string()))?;
 
         let mut encoded_tx = wrapped_tx.encode_to_vec();
         encoded_tx.insert(0, TxType::EIP4844.into());
@@ -132,21 +281,12 @@ impl EthClient {
         self.send_raw_transaction(encoded_tx.as_slice()).await
     }
 
-    /// Sends a [WrappedTransaction] with retries and gas bumping.
-    ///
-    /// The total wait time for each retry is determined by dividing the `max_seconds_to_wait`
-    /// by the `retries` parameter. The transaction is sent again with a gas bump if the receipt
-    /// is not confirmed within each retry period.
-    ///
-    /// seconds_per_retry = max_seconds_to_wait / retries;
-    pub async fn send_wrapped_transaction_with_retry(
+    pub async fn send_wrapped_transaction(
         &self,
         wrapped_tx: &WrappedTransaction,
         private_key: &SecretKey,
-        max_seconds_to_wait: u64,
-        retries: u64,
     ) -> Result<H256, EthClientError> {
-        let tx_hash_res = match wrapped_tx {
+        match wrapped_tx {
             WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
                 self.send_eip4844_transaction(wrapped_eip4844_transaction, private_key)
                     .await
@@ -159,91 +299,7 @@ impl EthClient {
                 self.send_privileged_l2_transaction(privileged_l2_transaction)
                     .await
             }
-        };
-
-        // Check if the tx is `already known`, bump gas and resend it.
-        let mut tx_hash = match tx_hash_res {
-            Ok(hash) => hash,
-            Err(e) => {
-                let error = format!("{e}");
-                if error.contains("already known")
-                    || error.contains("replacement transaction underpriced")
-                {
-                    H256::zero()
-                } else {
-                    return Err(e);
-                }
-            }
-        };
-
-        let mut wrapped_tx = wrapped_tx.clone();
-
-        let seconds_per_retry = max_seconds_to_wait / retries;
-        let timer_total = Instant::now();
-
-        for r in 0..retries {
-            // Check if we are not waiting more than needed.
-            if timer_total.elapsed().as_secs() > max_seconds_to_wait {
-                return Err(EthClientError::Custom(
-                    "TimeOut: Failed to send_wrapped_transaction_with_retry".to_owned(),
-                ));
-            }
-
-            // Wait for the receipt with some time between retries.
-            let timer_per_retry = Instant::now();
-            while timer_per_retry.elapsed().as_secs() < seconds_per_retry {
-                match self.get_transaction_receipt(tx_hash).await? {
-                    Some(_) => return Ok(tx_hash),
-                    None => sleep(Duration::from_secs(1)).await,
-                }
-            }
-
-            // If receipt is not found after the time period, increase gas and resend the transaction.
-            tx_hash = match &mut wrapped_tx {
-                WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
-                    warn!("Resending EIP4844Transaction, attempts [{r}/{retries}]");
-                    self.bump_and_resend_eip4844(wrapped_eip4844_transaction, private_key)
-                        .await?
-                }
-                WrappedTransaction::EIP1559(eip1559_transaction) => {
-                    warn!("Resending EIP1559Transaction, attempts [{r}/{retries}]");
-                    self.bump_and_resend_eip1559(eip1559_transaction, private_key)
-                        .await?
-                }
-                WrappedTransaction::L2(privileged_l2_transaction) => {
-                    warn!("Resending PrivilegedL2Transaction, attempts [{r}/{retries}]");
-                    self.bump_and_resend_privileged_l2(privileged_l2_transaction, private_key)
-                        .await?
-                }
-            };
         }
-
-        // If the loop ends without success, return a timeout error
-        Err(EthClientError::Custom(
-            "Max retries exceeded while waiting for transaction receipt".to_owned(),
-        ))
-    }
-
-    pub async fn bump_and_resend_eip1559(
-        &self,
-        tx: &mut EIP1559Transaction,
-        private_key: &SecretKey,
-    ) -> Result<H256, EthClientError> {
-        let from = get_address_from_secret_key(private_key).map_err(|e| {
-            EthClientError::Custom(format!("Failed to get_address_from_secret_key: {e}"))
-        })?;
-        // Sometimes the penalty is a 100%
-        // Increase max fee per gas by 110% (set it to 210% of the original)
-        self.bump_eip1559(tx, 110);
-        let wrapped_tx = &mut WrappedTransaction::EIP1559(tx.clone());
-        self.estimate_gas_for_wrapped_tx(wrapped_tx, from).await?;
-
-        if let WrappedTransaction::EIP1559(eip1559) = wrapped_tx {
-            tx.max_fee_per_gas = eip1559.max_fee_per_gas;
-            tx.max_priority_fee_per_gas = eip1559.max_fee_per_gas;
-            tx.gas_limit = eip1559.gas_limit;
-        }
-        self.send_eip1559_transaction(tx, private_key).await
     }
 
     /// Increase max fee per gas by percentage% (set it to (100+percentage)% of the original)
@@ -252,28 +308,105 @@ impl EthClient {
         tx.max_priority_fee_per_gas += (tx.max_priority_fee_per_gas * (100 + percentage)) / 100;
     }
 
-    pub async fn bump_and_resend_eip4844(
+    pub async fn send_tx_bump_gas_exponential_backoff(
         &self,
-        wrapped_tx: &mut WrappedEIP4844Transaction,
+        wrapped_tx: &mut WrappedTransaction,
         private_key: &SecretKey,
     ) -> Result<H256, EthClientError> {
-        let from = get_address_from_secret_key(private_key).map_err(|e| {
-            EthClientError::Custom(format!("Failed to get_address_from_secret_key: {e}"))
-        })?;
-        // Sometimes the penalty is a 100%
-        // Increase max fee per gas by 110% (set it to 210% of the original)
-        self.bump_eip4844(wrapped_tx, 110);
-        let wrapped_eip4844 = &mut WrappedTransaction::EIP4844(wrapped_tx.clone());
-        self.estimate_gas_for_wrapped_tx(wrapped_eip4844, from)
-            .await?;
+        let mut number_of_retries = 0;
 
-        if let WrappedTransaction::EIP4844(eip4844) = wrapped_eip4844 {
-            wrapped_tx.tx.max_fee_per_gas = eip4844.tx.max_fee_per_gas;
-            wrapped_tx.tx.max_priority_fee_per_gas = eip4844.tx.max_fee_per_gas;
-            wrapped_tx.tx.gas = eip4844.tx.gas;
-            wrapped_tx.tx.max_fee_per_blob_gas = eip4844.tx.max_fee_per_blob_gas;
+        'outer: while number_of_retries < self.max_number_of_retries {
+            if let Some(max_fee_per_gas) = self.maximum_allowed_max_fee_per_gas {
+                let (tx_max_fee, tx_max_priority_fee) = match wrapped_tx {
+                    WrappedTransaction::EIP4844(tx) => (
+                        &mut tx.tx.max_fee_per_gas,
+                        &mut tx.tx.max_priority_fee_per_gas,
+                    ),
+                    WrappedTransaction::EIP1559(tx) => {
+                        (&mut tx.max_fee_per_gas, &mut tx.max_priority_fee_per_gas)
+                    }
+                    WrappedTransaction::L2(tx) => {
+                        (&mut tx.max_fee_per_gas, &mut tx.max_priority_fee_per_gas)
+                    }
+                };
+
+                if *tx_max_fee > max_fee_per_gas {
+                    *tx_max_fee = max_fee_per_gas;
+
+                    // Ensure that max_priority_fee_per_gas does not exceed max_fee_per_gas
+                    if *tx_max_priority_fee > *tx_max_fee {
+                        *tx_max_priority_fee = *tx_max_fee;
+                    }
+
+                    warn!(
+                        "max_fee_per_gas exceeds the allowed limit, adjusting it to {max_fee_per_gas}"
+                    );
+                }
+            }
+
+            // Check blob gas fees only for EIP4844 transactions
+            if let WrappedTransaction::EIP4844(tx) = wrapped_tx {
+                if let Some(max_fee_per_blob_gas) = self.maximum_allowed_max_fee_per_blob_gas {
+                    if tx.tx.max_fee_per_blob_gas > U256::from(max_fee_per_blob_gas) {
+                        tx.tx.max_fee_per_blob_gas = U256::from(max_fee_per_blob_gas);
+                        warn!(
+                            "max_fee_per_blob_gas exceeds the allowed limit, adjusting it to {max_fee_per_blob_gas}"
+                        );
+                    }
+                }
+            }
+            let tx_hash = self
+                .send_wrapped_transaction(wrapped_tx, private_key)
+                .await?;
+
+            if number_of_retries > 0 {
+                warn!(
+                    "Resending Transaction after bumping gas, attempts [{number_of_retries}/{}]\nTxHash: {tx_hash:#x}",
+                    self.max_number_of_retries
+                );
+            }
+
+            let mut receipt = self.get_transaction_receipt(tx_hash).await?;
+
+            let mut attempt = 1;
+            let attempts_to_wait_in_seconds = self
+                .backoff_factor
+                .pow(number_of_retries as u32)
+                .clamp(self.min_retry_delay, self.max_retry_delay);
+            while receipt.is_none() {
+                if attempt >= (attempts_to_wait_in_seconds / WAIT_TIME_FOR_RECEIPT_SECONDS) {
+                    // We waited long enough for the receipt but did not find it, bump gas
+                    // and go to the next one.
+                    match wrapped_tx {
+                        WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
+                            self.bump_eip4844(wrapped_eip4844_transaction, 30);
+                        }
+                        WrappedTransaction::EIP1559(eip1559_transaction) => {
+                            self.bump_eip1559(eip1559_transaction, 30);
+                        }
+                        WrappedTransaction::L2(privileged_l2_transaction) => {
+                            self.bump_privileged_l2(privileged_l2_transaction, 30);
+                        }
+                    }
+
+                    number_of_retries += 1;
+                    continue 'outer;
+                }
+
+                attempt += 1;
+
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    WAIT_TIME_FOR_RECEIPT_SECONDS,
+                ))
+                .await;
+
+                receipt = self.get_transaction_receipt(tx_hash).await?;
+            }
+
+            return Ok(tx_hash);
         }
-        self.send_eip4844_transaction(wrapped_tx, private_key).await
+
+        Err(EthClientError::TimeoutError)
     }
 
     /// Increase max fee per gas by percentage% (set it to (100+percentage)% of the original)
@@ -287,27 +420,6 @@ impl EthClient {
             .max_fee_per_blob_gas
             .saturating_mul(U256::from(factor))
             .div(10);
-    }
-
-    pub async fn bump_and_resend_privileged_l2(
-        &self,
-        tx: &mut PrivilegedL2Transaction,
-        private_key: &SecretKey,
-    ) -> Result<H256, EthClientError> {
-        let from = get_address_from_secret_key(private_key).map_err(|e| {
-            EthClientError::Custom(format!("Failed to get_address_from_secret_key: {e}"))
-        })?;
-        // Sometimes the penalty is a 100%
-        // Increase max fee per gas by 110% (set it to 210% of the original)
-        self.bump_privileged_l2(tx, 110);
-        let wrapped_tx = &mut WrappedTransaction::L2(tx.clone());
-        self.estimate_gas_for_wrapped_tx(wrapped_tx, from).await?;
-        if let WrappedTransaction::L2(l2_tx) = wrapped_tx {
-            tx.max_fee_per_gas = l2_tx.max_fee_per_gas;
-            tx.max_priority_fee_per_gas = l2_tx.max_fee_per_gas;
-            tx.gas_limit = l2_tx.gas_limit;
-        }
-        self.send_privileged_l2_transaction(tx).await
     }
 
     /// Increase max fee per gas by percentage% (set it to (100+percentage)% of the original)
@@ -330,20 +442,21 @@ impl EthClient {
         &self,
         transaction: GenericTransaction,
     ) -> Result<u64, EthClientError> {
-        // If the transaction.to field matches TxKind::Create, we use an empty string.
-        // In this way, when the blockchain receives the request, it deserializes the json into a GenericTransaction,
-        // with the 'to' field set to TxKind::Create.
-        // The TxKind has TxKind::Create as #[default]
-        // https://github.com/lambdaclass/ethrex/blob/41b124c39030ad5d0b2674d7369be3599c7a3008/crates/common/types/transaction.rs#L267
         let to = match transaction.to {
-            TxKind::Call(addr) => format!("{addr:#x}"),
-            TxKind::Create => String::new(),
+            TxKind::Call(addr) => Some(format!("{addr:#x}")),
+            TxKind::Create => None,
         };
+        let blob_versioned_hashes_str: Vec<_> = transaction
+            .blob_versioned_hashes
+            .into_iter()
+            .map(|hash| format!("{hash:#x}"))
+            .collect();
         let mut data = json!({
             "to": to,
             "input": format!("0x{:#x}", transaction.input),
             "from": format!("{:#x}", transaction.from),
             "value": format!("{:#x}", transaction.value),
+            "blobVersionedHashes": blob_versioned_hashes_str
         });
 
         // Add the nonce just if present, otherwise the RPC will use the latest nonce
@@ -363,20 +476,19 @@ impl EthClient {
         match self.send_request(request).await {
             Ok(RpcResponse::Success(result)) => {
                 let res = serde_json::from_value::<String>(result.result)
-                    .map_err(EstimateGasPriceError::SerdeJSONError)?;
-                let res = res.get(2..).ok_or(EstimateGasPriceError::Custom(
+                    .map_err(EstimateGasError::SerdeJSONError)?;
+                let res = res.get(2..).ok_or(EstimateGasError::Custom(
                     "Failed to slice index response in estimate_gas".to_owned(),
                 ))?;
                 u64::from_str_radix(res, 16)
             }
-            .map_err(EstimateGasPriceError::ParseIntError)
+            .map_err(EstimateGasError::ParseIntError)
             .map_err(EthClientError::from),
             Ok(RpcResponse::Error(error_response)) => {
                 let error_data = if let Some(error_data) = error_response.error.data {
                     if &error_data == "0x" {
                         "unknown error".to_owned()
                     } else {
-                        println!("{error_data}");
                         let abi_decoded_error_data = hex::decode(
                             error_data.strip_prefix("0x").ok_or(EthClientError::Custom(
                                 "Failed to strip_prefix in estimate_gas".to_owned(),
@@ -419,11 +531,30 @@ impl EthClient {
                 } else {
                     "unknown error".to_owned()
                 };
-                Err(EstimateGasPriceError::RPCError(format!(
+                Err(EstimateGasError::RPCError(format!(
                     "{}: {}",
                     error_response.error.message, error_data
                 ))
                 .into())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn get_max_priority_fee(&self) -> Result<u64, EthClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "eth_maxPriorityFeePerGas".to_string(),
+            params: None,
+        };
+
+        match self.send_request(request).await {
+            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
+                .map_err(GetMaxPriorityFeeError::SerdeJSONError)
+                .map_err(EthClientError::from),
+            Ok(RpcResponse::Error(error_response)) => {
+                Err(GetMaxPriorityFeeError::RPCError(error_response.error.message).into())
             }
             Err(error) => Err(error),
         }
@@ -448,12 +579,25 @@ impl EthClient {
         }
     }
 
-    pub async fn get_nonce(&self, address: Address) -> Result<u64, EthClientError> {
+    pub async fn get_gas_price_with_extra(
+        &self,
+        bump_percent: u64,
+    ) -> Result<U256, EthClientError> {
+        let gas_price = self.get_gas_price().await?;
+
+        Ok((gas_price * (100 + bump_percent)) / 100)
+    }
+
+    pub async fn get_nonce(
+        &self,
+        address: Address,
+        block: BlockByNumber,
+    ) -> Result<u64, EthClientError> {
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
             method: "eth_getTransactionCount".to_string(),
-            params: Some(vec![json!(format!("{address:#x}")), json!("latest")]),
+            params: Some(vec![json!(format!("{address:#x}")), block.into()]),
         };
 
         match self.send_request(request).await {
@@ -513,36 +657,18 @@ impl EthClient {
         }
     }
 
-    pub async fn get_next_block_to_commit(
-        eth_client: &EthClient,
-        on_chain_proposer_address: Address,
-    ) -> Result<u64, EthClientError> {
-        Self::_call_block_variable(
-            eth_client,
-            b"nextBlockToCommit()",
-            on_chain_proposer_address,
-        )
-        .await
-    }
-
     /// Fetches a block from the Ethereum blockchain by its number or the latest/earliest/pending block.
     /// If no `block_number` is provided, get the latest.
     pub async fn get_block_by_number(
         &self,
         block: BlockByNumber,
     ) -> Result<RpcBlock, EthClientError> {
-        let r = match block {
-            BlockByNumber::Number(n) => format!("{n:#x}"),
-            BlockByNumber::Latest => "latest".to_owned(),
-            BlockByNumber::Earliest => "earliest".to_owned(),
-            BlockByNumber::Pending => "pending".to_owned(),
-        };
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
             method: "eth_getBlockByNumber".to_string(),
             // With false it just returns the hash of the transactions.
-            params: Some(vec![json!(r), json!(false)]),
+            params: Some(vec![block.into(), json!(false)]),
         };
 
         match self.send_request(request).await {
@@ -558,44 +684,23 @@ impl EthClient {
 
     pub async fn get_logs(
         &self,
-        from_block: Option<U256>,
-        to_block: Option<U256>,
-        address: Option<Address>,
-        topic: Option<H256>,
-        block_hash: Option<H256>,
+        from_block: U256,
+        to_block: U256,
+        address: Address,
+        topic: H256,
     ) -> Result<Vec<RpcLog>, EthClientError> {
-        let mut params_obj = serde_json::Map::new();
-
-        if let Some(fb) = from_block {
-            params_obj.insert(
-                "fromBlock".to_string(),
-                serde_json::json!(format!("{fb:#x}")),
-            );
-        }
-        if let Some(tb) = to_block {
-            params_obj.insert("toBlock".to_string(), serde_json::json!(format!("{tb:#x}")));
-        }
-        if let Some(addr) = address {
-            params_obj.insert(
-                "address".to_string(),
-                serde_json::json!(format!("{addr:#x}")),
-            );
-        }
-        if let Some(t) = topic {
-            params_obj.insert("topics".to_string(), serde_json::json!([format!("{t:#x}")]));
-        }
-        if let Some(bh) = block_hash {
-            params_obj.insert(
-                "blockHash".to_string(),
-                serde_json::json!([format!("{bh:#x}")]),
-            );
-        }
-
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
             method: "eth_getLogs".to_string(),
-            params: Some(vec![serde_json::Value::Object(params_obj)]),
+            params: Some(vec![serde_json::json!(
+                {
+                    "fromBlock": format!("{:#x}", from_block),
+                    "toBlock": format!("{:#x}", to_block),
+                    "address": format!("{:#x}", address),
+                    "topics": [format!("{:#x}", topic)]
+                }
+            )]),
         };
 
         match self.send_request(request).await {
@@ -631,12 +736,35 @@ impl EthClient {
         }
     }
 
-    pub async fn get_balance(&self, address: Address) -> Result<U256, EthClientError> {
+    pub async fn get_balance(
+        &self,
+        address: Address,
+        block: BlockByNumber,
+    ) -> Result<U256, EthClientError> {
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
             method: "eth_getBalance".to_string(),
-            params: Some(vec![json!(format!("{:#x}", address)), json!("latest")]),
+            params: Some(vec![json!(format!("{:#x}", address)), block.into()]),
+        };
+
+        match self.send_request(request).await {
+            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
+                .map_err(GetBalanceError::SerdeJSONError)
+                .map_err(EthClientError::from),
+            Ok(RpcResponse::Error(error_response)) => {
+                Err(GetBalanceError::RPCError(error_response.error.message).into())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn get_chain_id(&self) -> Result<U256, EthClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "eth_chainId".to_string(),
+            params: None,
         };
 
         match self.send_request(request).await {
@@ -669,20 +797,35 @@ impl EthClient {
         })
     }
 
-    pub async fn get_chain_id(&self) -> Result<U256, EthClientError> {
+    pub async fn get_code(
+        &self,
+        address: Address,
+        block: BlockByNumber,
+    ) -> Result<Bytes, EthClientError> {
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
-            method: "eth_chainId".to_string(),
-            params: None,
+            method: "eth_getCode".to_string(),
+            params: Some(vec![json!(format!("{:#x}", address)), block.into()]),
         };
 
         match self.send_request(request).await {
-            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
-                .map_err(GetBalanceError::SerdeJSONError)
-                .map_err(EthClientError::from),
+            Ok(RpcResponse::Success(result)) => hex::decode(
+                &serde_json::from_value::<String>(result.result)
+                    .map(|hex_str| {
+                        hex_str
+                            .strip_prefix("0x")
+                            .map(ToString::to_string)
+                            .unwrap_or(hex_str)
+                    })
+                    .map_err(GetCodeError::SerdeJSONError)
+                    .map_err(EthClientError::from)?,
+            )
+            .map(Into::into)
+            .map_err(GetCodeError::NotHexError)
+            .map_err(EthClientError::from),
             Ok(RpcResponse::Error(error_response)) => {
-                Err(GetBalanceError::RPCError(error_response.error.message).into())
+                Err(GetCodeError::RPCError(error_response.error.message).into())
             }
             Err(error) => Err(error),
         }
@@ -691,7 +834,7 @@ impl EthClient {
     pub async fn get_transaction_by_hash(
         &self,
         tx_hash: H256,
-    ) -> Result<Option<GetTransactionByHashTransactionResponse>, EthClientError> {
+    ) -> Result<Option<GetTransactionByHashTransaction>, EthClientError> {
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
@@ -710,48 +853,60 @@ impl EthClient {
         }
     }
 
+    pub async fn set_gas_for_wrapped_tx(
+        &self,
+        wrapped_tx: &mut WrappedTransaction,
+        from: Address,
+    ) -> Result<(), EthClientError> {
+        let mut transaction = match wrapped_tx {
+            WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
+                GenericTransaction::from(wrapped_eip4844_transaction.clone().tx)
+            }
+            WrappedTransaction::EIP1559(eip1559_transaction) => {
+                GenericTransaction::from(eip1559_transaction.clone())
+            }
+            WrappedTransaction::L2(privileged_l2_transaction) => {
+                GenericTransaction::from(privileged_l2_transaction.clone())
+            }
+        };
+
+        transaction.from = from;
+        let gas_limit = self.estimate_gas(transaction).await?;
+        match wrapped_tx {
+            WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
+                wrapped_eip4844_transaction.tx.gas = gas_limit;
+            }
+            WrappedTransaction::EIP1559(eip1559_transaction) => {
+                eip1559_transaction.gas_limit = gas_limit;
+            }
+            WrappedTransaction::L2(privileged_l2_transaction) => {
+                privileged_l2_transaction.gas_limit = gas_limit;
+            }
+        }
+
+        Ok(())
+    }
+
     pub async fn estimate_gas_for_wrapped_tx(
         &self,
         wrapped_tx: &mut WrappedTransaction,
         from: H160,
     ) -> Result<u64, EthClientError> {
-        loop {
-            let mut transaction = match wrapped_tx {
-                WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
-                    GenericTransaction::from(wrapped_eip4844_transaction.clone().tx)
-                }
-                WrappedTransaction::EIP1559(eip1559_transaction) => {
-                    GenericTransaction::from(eip1559_transaction.clone())
-                }
-                WrappedTransaction::L2(privileged_l2_transaction) => {
-                    GenericTransaction::from(privileged_l2_transaction.clone())
-                }
-            };
+        let mut transaction = match wrapped_tx {
+            WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
+                GenericTransaction::from(wrapped_eip4844_transaction.clone().tx)
+            }
+            WrappedTransaction::EIP1559(eip1559_transaction) => {
+                GenericTransaction::from(eip1559_transaction.clone())
+            }
+            WrappedTransaction::L2(privileged_l2_transaction) => {
+                GenericTransaction::from(privileged_l2_transaction.clone())
+            }
+        };
 
-            transaction.from = from;
-
-            match self.estimate_gas(transaction).await {
-                Ok(gas_limit) => return Ok(gas_limit),
-                Err(e) => {
-                    let error = format!("{e}").to_owned();
-                    if error.contains("transaction underpriced") {
-                        match wrapped_tx {
-                            WrappedTransaction::EIP4844(wrapped_eip4844_transaction) => {
-                                self.bump_eip4844(wrapped_eip4844_transaction, 110);
-                            }
-                            WrappedTransaction::EIP1559(eip1559_transaction) => {
-                                self.bump_eip1559(eip1559_transaction, 110);
-                            }
-                            WrappedTransaction::L2(privileged_l2_transaction) => {
-                                self.bump_privileged_l2(privileged_l2_transaction, 110);
-                            }
-                        };
-                        continue;
-                    }
-                    return Err(e);
-                }
-            };
-        }
+        transaction.from = from;
+        transaction.nonce = None;
+        self.estimate_gas(transaction).await
     }
 
     /// Build an EIP1559 transaction with the given parameters.
@@ -765,9 +920,7 @@ impl EthClient {
         from: Address,
         calldata: Bytes,
         overrides: Overrides,
-        bump_retries: u64,
     ) -> Result<EIP1559Transaction, EthClientError> {
-        let mut get_gas_price = 1;
         let mut tx = EIP1559Transaction {
             to: overrides.to.clone().unwrap_or(TxKind::Call(to)),
             chain_id: if let Some(chain_id) = overrides.chain_id {
@@ -780,58 +933,29 @@ impl EthClient {
             nonce: self
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
-            max_fee_per_gas: if let Some(gas_price) = overrides.max_fee_per_gas {
-                gas_price
-            } else {
-                get_gas_price = self.get_gas_price().await?.try_into().map_err(|_| {
-                    EthClientError::Custom("Failed at gas_price.try_into()".to_owned())
-                })?;
-
-                get_gas_price
-            },
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(get_gas_price),
+            max_fee_per_gas: self
+                .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
+                .await?,
+            max_priority_fee_per_gas: self
+                .priority_fee_from_override_or_rpc(overrides.max_priority_fee_per_gas)
+                .await?,
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
             ..Default::default()
         };
 
-        let mut wrapped_tx;
-
         if let Some(overrides_gas_limit) = overrides.gas_limit {
             tx.gas_limit = overrides_gas_limit;
-            Ok(tx)
         } else {
-            let mut retry = 0_u64;
-            while retry < bump_retries {
-                wrapped_tx = WrappedTransaction::EIP1559(tx.clone());
-                match self
-                    .estimate_gas_for_wrapped_tx(&mut wrapped_tx, from)
-                    .await
-                {
-                    Ok(gas_limit) => {
-                        // Estimation succeeded.
-                        tx.gas_limit = gas_limit;
-                        return Ok(tx);
-                    }
-                    Err(e) => {
-                        let error = format!("{e}");
-                        if error.contains("replacement transaction underpriced") {
-                            warn!("Bumping gas while building: already known");
-                            retry += 1;
-                            self.bump_eip1559(&mut tx, 110);
-                            continue;
-                        }
-                        return Err(e);
-                    }
-                }
-            }
-            Err(EthClientError::EstimateGasPriceError(
-                EstimateGasPriceError::Custom(
-                    "Exceeded maximum retries while estimating gas.".to_string(),
-                ),
-            ))
+            let mut wrapped_tx = WrappedTransaction::EIP1559(tx.clone());
+            let gas_limit = self
+                .estimate_gas_for_wrapped_tx(&mut wrapped_tx, from)
+                .await?;
+            tx.gas_limit = gas_limit;
         }
+
+        Ok(tx)
     }
 
     /// Build an EIP4844 transaction with the given parameters.
@@ -846,10 +970,9 @@ impl EthClient {
         calldata: Bytes,
         overrides: Overrides,
         blobs_bundle: BlobsBundle,
-        bump_retries: u64,
     ) -> Result<WrappedEIP4844Transaction, EthClientError> {
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
-        let mut get_gas_price = 1;
+
         let tx = EIP4844Transaction {
             to,
             chain_id: if let Some(chain_id) = overrides.chain_id {
@@ -862,16 +985,12 @@ impl EthClient {
             nonce: self
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
-            max_fee_per_gas: if let Some(gas_price) = overrides.max_fee_per_gas {
-                gas_price
-            } else {
-                get_gas_price = self.get_gas_price().await?.try_into().map_err(|_| {
-                    EthClientError::Custom("Failed at gas_price.try_into()".to_owned())
-                })?;
-
-                get_gas_price
-            },
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(get_gas_price),
+            max_fee_per_gas: self
+                .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
+                .await?,
+            max_priority_fee_per_gas: self
+                .priority_fee_from_override_or_rpc(overrides.max_priority_fee_per_gas)
+                .await?,
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
@@ -881,42 +1000,17 @@ impl EthClient {
         };
 
         let mut wrapped_eip4844 = WrappedEIP4844Transaction { tx, blobs_bundle };
-        let mut wrapped_tx;
         if let Some(overrides_gas_limit) = overrides.gas_limit {
             wrapped_eip4844.tx.gas = overrides_gas_limit;
-            Ok(wrapped_eip4844)
         } else {
-            let mut retry = 0_u64;
-            while retry < bump_retries {
-                wrapped_tx = WrappedTransaction::EIP4844(wrapped_eip4844.clone());
-
-                match self
-                    .estimate_gas_for_wrapped_tx(&mut wrapped_tx, from)
-                    .await
-                {
-                    Ok(gas_limit) => {
-                        // Estimation succeeded.
-                        wrapped_eip4844.tx.gas = gas_limit;
-                        return Ok(wrapped_eip4844);
-                    }
-                    Err(e) => {
-                        let error = format!("{e}");
-                        if error.contains("already known") {
-                            warn!("Bumping gas while building: already known");
-                            retry += 1;
-                            self.bump_eip4844(&mut wrapped_eip4844, 110);
-                            continue;
-                        }
-                        return Err(e);
-                    }
-                }
-            }
-            Err(EthClientError::EstimateGasPriceError(
-                EstimateGasPriceError::Custom(
-                    "Exceeded maximum retries while estimating gas.".to_string(),
-                ),
-            ))
+            let mut wrapped_tx = WrappedTransaction::EIP4844(wrapped_eip4844.clone());
+            let gas_limit = self
+                .estimate_gas_for_wrapped_tx(&mut wrapped_tx, from)
+                .await?;
+            wrapped_eip4844.tx.gas = gas_limit;
         }
+
+        Ok(wrapped_eip4844)
     }
 
     /// Build a PrivilegedL2 transaction with the given parameters.
@@ -927,14 +1021,14 @@ impl EthClient {
     pub async fn build_privileged_transaction(
         &self,
         to: Address,
+        recipient: Address,
         from: Address,
         calldata: Bytes,
         overrides: Overrides,
-        bump_retries: u64,
     ) -> Result<PrivilegedL2Transaction, EthClientError> {
-        let mut get_gas_price = 1;
         let mut tx = PrivilegedL2Transaction {
             to: TxKind::Call(to),
+            recipient,
             chain_id: if let Some(chain_id) = overrides.chain_id {
                 chain_id
             } else {
@@ -945,58 +1039,30 @@ impl EthClient {
             nonce: self
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
-            max_fee_per_gas: if let Some(gas_price) = overrides.max_fee_per_gas {
-                gas_price
-            } else {
-                get_gas_price = self.get_gas_price().await?.try_into().map_err(|_| {
-                    EthClientError::Custom("Failed at gas_price.try_into()".to_owned())
-                })?;
-
-                get_gas_price
-            },
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(get_gas_price),
+            max_fee_per_gas: self
+                .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
+                .await?,
+            max_priority_fee_per_gas: self
+                .priority_fee_from_override_or_rpc(overrides.max_priority_fee_per_gas)
+                .await?,
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
+            from,
             ..Default::default()
         };
 
-        let mut wrapped_tx;
-
         if let Some(overrides_gas_limit) = overrides.gas_limit {
             tx.gas_limit = overrides_gas_limit;
-            Ok(tx)
         } else {
-            let mut retry = 0_u64;
-            while retry < bump_retries {
-                wrapped_tx = WrappedTransaction::L2(tx.clone());
-                match self
-                    .estimate_gas_for_wrapped_tx(&mut wrapped_tx, from)
-                    .await
-                {
-                    Ok(gas_limit) => {
-                        // Estimation succeeded.
-                        tx.gas_limit = gas_limit;
-                        return Ok(tx);
-                    }
-                    Err(e) => {
-                        let error = format!("{e}");
-                        if error.contains("already known") {
-                            warn!("Bumping gas while building: already known");
-                            retry += 1;
-                            self.bump_privileged_l2(&mut tx, 110);
-                            continue;
-                        }
-                        return Err(e);
-                    }
-                }
-            }
-            Err(EthClientError::EstimateGasPriceError(
-                EstimateGasPriceError::Custom(
-                    "Exceeded maximum retries while estimating gas.".to_string(),
-                ),
-            ))
+            let mut wrapped_tx = WrappedTransaction::L2(tx.clone());
+            let gas_limit = self
+                .estimate_gas_for_wrapped_tx(&mut wrapped_tx, from)
+                .await?;
+            tx.gas_limit = gas_limit;
         }
+
+        Ok(tx)
     }
 
     async fn get_nonce_from_overrides_or_rpc(
@@ -1007,45 +1073,81 @@ impl EthClient {
         if let Some(nonce) = overrides.nonce {
             return Ok(nonce);
         }
-        self.get_nonce(address).await
+        self.get_nonce(address, BlockByNumber::Latest).await
     }
 
-    pub async fn get_last_committed_block(
-        eth_client: &EthClient,
+    pub async fn get_last_committed_batch(
+        &self,
         on_chain_proposer_address: Address,
     ) -> Result<u64, EthClientError> {
-        Self::_call_block_variable(
-            eth_client,
-            b"lastCommittedBlock()",
-            on_chain_proposer_address,
-        )
-        .await
+        self._call_variable(b"lastCommittedBatch()", on_chain_proposer_address)
+            .await
     }
 
-    pub async fn get_last_verified_block(
-        eth_client: &EthClient,
+    pub async fn get_last_verified_batch(
+        &self,
         on_chain_proposer_address: Address,
     ) -> Result<u64, EthClientError> {
-        Self::_call_block_variable(
-            eth_client,
-            b"lastVerifiedBlock()",
-            on_chain_proposer_address,
-        )
-        .await
+        self._call_variable(b"lastVerifiedBatch()", on_chain_proposer_address)
+            .await
     }
 
     pub async fn get_last_fetched_l1_block(
-        eth_client: &EthClient,
+        &self,
         common_bridge_address: Address,
     ) -> Result<u64, EthClientError> {
-        Self::_call_block_variable(eth_client, b"lastFetchedL1Block()", common_bridge_address).await
+        self._call_variable(b"lastFetchedL1Block()", common_bridge_address)
+            .await
     }
 
-    async fn _call_block_variable(
-        eth_client: &EthClient,
+    pub async fn get_pending_deposit_logs(
+        &self,
+        common_bridge_address: Address,
+    ) -> Result<Vec<H256>, EthClientError> {
+        let response = self
+            ._generic_call(b"getPendingDepositLogs()", common_bridge_address)
+            .await?;
+        Self::from_hex_string_to_h256_array(&response)
+    }
+
+    pub fn from_hex_string_to_h256_array(hex_string: &str) -> Result<Vec<H256>, EthClientError> {
+        let bytes = hex::decode(hex_string.strip_prefix("0x").unwrap_or(hex_string))
+            .map_err(|_| EthClientError::Custom("Invalid hex string".to_owned()))?;
+
+        // The ABI encoding for dynamic arrays is:
+        // 1. Offset to data (32 bytes)
+        // 2. Length of array (32 bytes)
+        // 3. Array elements (each 32 bytes)
+        if bytes.len() < 64 {
+            return Err(EthClientError::Custom("Response too short".to_owned()));
+        }
+
+        // Get the offset (should be 0x20 for simple arrays)
+        let offset = U256::from_big_endian(&bytes[0..32]).as_usize();
+
+        // Get the length of the array
+        let length = U256::from_big_endian(&bytes[offset..offset + 32]).as_usize();
+
+        // Calculate the start of the array data
+        let data_start = offset + 32;
+        let data_end = data_start + (length * 32);
+
+        if data_end > bytes.len() {
+            return Err(EthClientError::Custom("Invalid array length".to_owned()));
+        }
+
+        // Convert the slice directly to H256 array
+        bytes[data_start..data_end]
+            .chunks_exact(32)
+            .map(|chunk| Ok(H256::from_slice(chunk)))
+            .collect()
+    }
+
+    async fn _generic_call(
+        &self,
         selector: &[u8],
-        on_chain_proposer_address: Address,
-    ) -> Result<u64, EthClientError> {
+        contract_address: Address,
+    ) -> Result<String, EthClientError> {
         let selector = keccak(selector)
             .as_bytes()
             .get(..4)
@@ -1058,18 +1160,45 @@ impl EthClient {
         let leading_zeros = 32 - ((calldata.len() - 4) % 32);
         calldata.extend(vec![0; leading_zeros]);
 
-        let hex_str = eth_client
-            .call(
-                on_chain_proposer_address,
-                calldata.into(),
-                Overrides::default(),
-            )
+        let hex_string = self
+            .call(contract_address, calldata.into(), Overrides::default())
             .await?;
 
-        let value = from_hex_string_to_u256(&hex_str)?.try_into().map_err(|_| {
-            EthClientError::Custom("Failed to convert from_hex_string_to_u256()".to_owned())
-        })?;
+        Ok(hex_string)
+    }
 
+    async fn _call_variable(
+        &self,
+        selector: &[u8],
+        on_chain_proposer_address: Address,
+    ) -> Result<u64, EthClientError> {
+        let hex_string = self
+            ._generic_call(selector, on_chain_proposer_address)
+            .await?;
+
+        let value = from_hex_string_to_u256(&hex_string)?
+            .try_into()
+            .map_err(|_| {
+                EthClientError::Custom("Failed to convert from_hex_string_to_u256()".to_owned())
+            })?;
+
+        Ok(value)
+    }
+
+    async fn _call_address_variable(
+        eth_client: &EthClient,
+        selector: &[u8],
+        on_chain_proposer_address: Address,
+    ) -> Result<Address, EthClientError> {
+        let hex_string =
+            Self::_generic_call(eth_client, selector, on_chain_proposer_address).await?;
+
+        let hex_str = &hex_string.strip_prefix("0x").ok_or(EthClientError::Custom(
+            "Couldn't strip prefix from request.".to_owned(),
+        ))?[24..]; // Get the needed bytes
+
+        let value = Address::from_str(hex_str)
+            .map_err(|_| EthClientError::Custom("Failed to convert from_str()".to_owned()))?;
         Ok(value)
     }
 
@@ -1099,51 +1228,87 @@ impl EthClient {
         ))
     }
 
-    pub async fn get_code(
+    pub async fn get_message_proof(
         &self,
-        address: Address,
-        block: String,
-    ) -> Result<String, EthClientError> {
+        transaction_hash: H256,
+    ) -> Result<Option<Vec<L1MessageProof>>, EthClientError> {
+        use errors::GetMessageProofError;
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
             jsonrpc: "2.0".to_string(),
-            method: "eth_getCode".to_string(),
-            params: Some(vec![json!(address), json!(block)]),
+            method: "ethrex_getMessageProof".to_string(),
+            params: Some(vec![json!(format!("{transaction_hash:#x}"))]),
         };
 
         match self.send_request(request).await {
             Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
-                .map_err(SendRawTransactionError::SerdeJSONError)
+                .map_err(GetMessageProofError::SerdeJSONError)
                 .map_err(EthClientError::from),
             Ok(RpcResponse::Error(error_response)) => {
-                Err(SendRawTransactionError::RPCError(error_response.error.message).into())
+                Err(GetMessageProofError::RPCError(error_response.error.message).into())
             }
             Err(error) => Err(error),
         }
     }
 
-    pub async fn get_logs_from_signature(
+    pub async fn wait_for_message_proof(
         &self,
-        from_block: U256,
-        to_block: U256,
-        address: Address,
-        signature: &str,
-    ) -> Result<Vec<RpcLog>, EthClientError> {
-        let topic = keccak(signature);
-        self.get_logs(
-            Some(from_block),
-            Some(to_block),
-            Some(address),
-            Some(topic),
-            None,
-        )
-        .await
+        transaction_hash: H256,
+        max_retries: u64,
+    ) -> Result<Vec<L1MessageProof>, EthClientError> {
+        let mut message_proof = self.get_message_proof(transaction_hash).await?;
+        let mut r#try = 1;
+        while message_proof.is_none() {
+            println!(
+                "[{try}/{max_retries}] Retrying to get message proof for tx {transaction_hash:#x}"
+            );
+
+            if max_retries == r#try {
+                return Err(EthClientError::Custom(format!(
+                    "L1Message proof for tx {transaction_hash:#x} not found after {max_retries} retries"
+                )));
+            }
+            r#try += 1;
+
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+            message_proof = self.get_message_proof(transaction_hash).await?;
+        }
+        message_proof.ok_or(EthClientError::Custom("L1Message proof is None".to_owned()))
+    }
+
+    async fn get_fee_from_override_or_get_gas_price(
+        &self,
+        maybe_gas_fee: Option<u64>,
+    ) -> Result<u64, EthClientError> {
+        if let Some(gas_fee) = maybe_gas_fee {
+            return Ok(gas_fee);
+        }
+        self.get_gas_price()
+            .await?
+            .try_into()
+            .map_err(|_| EthClientError::Custom("Failed to get gas for fee".to_owned()))
+    }
+
+    async fn priority_fee_from_override_or_rpc(
+        &self,
+        maybe_priority_fee: Option<u64>,
+    ) -> Result<u64, EthClientError> {
+        if let Some(priority_fee) = maybe_priority_fee {
+            return Ok(priority_fee);
+        }
+
+        if let Ok(priority_fee) = self.get_max_priority_fee().await {
+            return Ok(priority_fee);
+        }
+
+        self.get_fee_from_override_or_get_gas_price(None).await
     }
 }
 
-pub fn from_hex_string_to_u256(hex_str: &str) -> Result<U256, EthClientError> {
-    let hex_string = hex_str.strip_prefix("0x").ok_or(EthClientError::Custom(
-        "Couldn't strip prefix from last_committed_block.".to_owned(),
+pub fn from_hex_string_to_u256(hex_string: &str) -> Result<U256, EthClientError> {
+    let hex_string = hex_string.strip_prefix("0x").ok_or(EthClientError::Custom(
+        "Couldn't strip prefix from request.".to_owned(),
     ))?;
 
     if hex_string.is_empty() {
@@ -1183,7 +1348,7 @@ pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, Et
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct GetTransactionByHashTransactionResponse {
+pub struct GetTransactionByHashTransaction {
     #[serde(default, with = "ethrex_common::serde_utils::u64::hex_str")]
     pub chain_id: u64,
     #[serde(default, with = "ethrex_common::serde_utils::u64::hex_str")]
@@ -1198,7 +1363,7 @@ pub struct GetTransactionByHashTransactionResponse {
     pub to: Address,
     #[serde(default)]
     pub value: U256,
-    #[serde(default)]
+    #[serde(default, with = "ethrex_common::serde_utils::vec_u8", alias = "input")]
     pub data: Vec<u8>,
     #[serde(default)]
     pub access_list: Vec<(Address, Vec<H256>)>,
@@ -1220,32 +1385,33 @@ pub struct GetTransactionByHashTransactionResponse {
     pub hash: H256,
     #[serde(default, with = "ethrex_common::serde_utils::u64::hex_str")]
     pub transaction_index: u64,
+    #[serde(default)]
+    pub blob_versioned_hashes: Option<Vec<H256>>,
 }
 
-impl fmt::Display for GetTransactionByHashTransactionResponse {
+impl fmt::Display for GetTransactionByHashTransaction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             r#"
-            chain_id: {},
-            nonce: {},
-            max_priority_fee_per_gas: {},
-            max_fee_per_gas: {},
-            gas_limit: {},
-            to: {:#x},
-            value: {},
-            data: {:#?},
-            access_list: {:#?},
-            type: {:?},
-            signature_y_parity: {},
-            signature_r: {:x},
-            signature_s: {:x},
-            block_number: {},
-            block_hash: {:#x},
-            from: {:#x},
-            hash: {:#x},
-            transaction_index: {}
-            "#,
+chain_id: {},
+nonce: {},
+max_priority_fee_per_gas: {},
+max_fee_per_gas: {},
+gas_limit: {},
+to: {:#x},
+value: {},
+data: {:#?},
+access_list: {:#?},
+type: {:?},
+signature_y_parity: {},
+signature_r: {:x},
+signature_s: {:x},
+block_number: {},
+block_hash: {:#x},
+from: {:#x},
+hash: {:#x},
+transaction_index: {}"#,
             self.chain_id,
             self.nonce,
             self.max_priority_fee_per_gas,
@@ -1263,7 +1429,13 @@ impl fmt::Display for GetTransactionByHashTransactionResponse {
             self.block_hash,
             self.from,
             self.hash,
-            self.transaction_index
-        )
+            self.transaction_index,
+        )?;
+
+        if let Some(blob_versioned_hashes) = &self.blob_versioned_hashes {
+            write!(f, "\nblob_versioned_hashes: {blob_versioned_hashes:#?}")?;
+        }
+
+        fmt::Result::Ok(())
     }
 }

--- a/sdk/src/sdk.rs
+++ b/sdk/src/sdk.rs
@@ -22,7 +22,7 @@ pub async fn transfer(
     overrides: Overrides,
 ) -> Result<H256, EthClientError> {
     let tx = client
-        .build_eip1559_transaction(to, from, Default::default(), overrides, 10)
+        .build_eip1559_transaction(to, from, Default::default(), overrides)
         .await?;
     client.send_eip1559_transaction(&tx, &private_key).await
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

`rex l2 claim-withdraw` stopped working with the latest ethrex changes.

**Description**

- Fix `rex l2 claim-withdraw`
    - Add amount to claim as an arg for `rex l2 claim-withdraw`.
    - Update logic.
- Update the `eth_client` module with the latest ethrex changes.
- Update the `sdk/l2` module with the latest ethrex changes.

