### PR TITLE
fix(sdk): fix noisy deploy

### DIFF
--- a/sdk/src/client/eth/eth_sender.rs
+++ b/sdk/src/client/eth/eth_sender.rs
@@ -107,9 +107,6 @@ impl EthClient {
                 EthClientError::Custom("Failed to get deployed_address".to_owned()),
             )?);
 
-        self.wait_for_transaction_receipt(deploy_tx_hash, 1000)
-            .await?;
-
         Ok((deploy_tx_hash, deployed_address))
     }
 }

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -86,7 +86,7 @@ impl From<u64> for BlockByNumber {
 impl Display for BlockByNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BlockByNumber::Number(n) => write!(f, "{:#x}", n),
+            BlockByNumber::Number(n) => write!(f, "{n:#x}"),
             BlockByNumber::Latest => write!(f, "latest"),
             BlockByNumber::Earliest => write!(f, "earliest"),
             BlockByNumber::Pending => write!(f, "pending"),

--- a/sdk/src/l2/withdraw.rs
+++ b/sdk/src/l2/withdraw.rs
@@ -166,7 +166,7 @@ pub async fn get_withdraw_merkle_proof(
     Ok((
         index
             .try_into()
-            .map_err(|err| EthClientError::Custom(format!("index does not fit in u64: {}", err)))?,
+            .map_err(|err| EthClientError::Custom(format!("index does not fit in u64: {err}")))?,
         path,
     ))
 }


### PR DESCRIPTION
**Motivation**

The deploy command has a `--print-address` argument, that ensures only the address of the deployed contract is printed.

In #148, a `wait_for_transaction_receipt` call was added to the sdk deploy path, which is noisy and redundant (deploy calls an optionally silent version of wait_for_transaction_receipt).

**Description**

Removes the extra `wait_for_transaction_receipt` call.
