### PR TITLE
feat(docker): add Docker support and usage instructions in README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Build artifacts
+target/
+**/*.rs.bk
+*.pdb
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Documentation and assets
+README.md
+LICENSE
+assets/
+**/*.md
+
+# GitHub
+.github/
+
+# Other
+.env
+.env.local
+.env.*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Multi-stage build for Rex CLI
+# Stage 1: Build stage
+FROM rustlang/rust:nightly-slim AS builder
+
+# Install system dependencies needed for building
+RUN apt-get update && apt-get install -y \
+    git \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /rex
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY cli/ ./cli/
+COPY sdk/ ./sdk/
+
+# Build the CLI binary with optimizations
+RUN cargo build --release --bin rex
+
+# Stage 2: Runtime stage
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd -r -s /bin/false rex
+
+# Copy the built binary from builder stage
+COPY --from=builder /rex/target/release/rex /usr/local/bin/rex
+
+# Set permissions
+RUN chmod +x /usr/local/bin/rex
+
+# Switch to non-root user
+USER rex
+
+# Set entrypoint
+ENTRYPOINT ["rex"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,40 @@ To install it, you need to clone the repository and run the following command to
 make cli
 ```
 
+#### Using Docker
+
+Alternatively, you can use Docker to run Rex without installing Rust:
+
+```Shell
+# Build the Docker image
+docker build -t rex .
+
+# Run rex commands
+docker run --rm rex --help
+docker run --rm rex balance 0x... --rpc-url https://ethereum.node.url
+
+# For interactive usage, you can create an alias
+alias rex="docker run --rm rex"
+```
+
+##### Docker Networking
+
+To access services running on your host machine (like local blockchain nodes):
+
+```Shell
+# For local RPC nodes (e.g., local Ethereum node on port 8545)
+docker run --rm --add-host=host.docker.internal:host-gateway rex balance 0x... --rpc-url http://host.docker.internal:8545
+
+# Create an alias for easier usage with host access
+alias rex="docker run --rm --add-host=host.docker.internal:host-gateway rex"
+
+# Now you can use rex normally with local services
+rex balance 0x... --rpc-url http://host.docker.internal:8545
+rex l2 deposit --amount 1000000000000000000 --rpc-url http://host.docker.internal:8545
+```
+
+**Note**: By default, Docker containers cannot access `localhost` services on your host machine. The `--add-host=host.docker.internal:host-gateway` flag creates a bridge that allows the container to reach your host's services via `host.docker.internal`.
+
 ### Using the CLI
 
 After installing the CLI with `make cli`, run `rex` to display the help message and see the available commands.


### PR DESCRIPTION
Add the Docker support to Rex CLI with usage instructions in README file.

Resolves #136 

Closes #136 

