### PR TITLE
refactor(cli): simplify rex interface

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -228,39 +228,54 @@ Options:
 ```Shell
 Send a transaction
 
-Usage: rex send [OPTIONS] <TO> [VALUE] <PRIVATE_KEY> -- [SIGNATURE [ARGS]]
+Usage: rex send [OPTIONS] <TO> [ARGS]...
 
 Arguments:
   <TO>
-  [VALUE]        Value to send in wei [default: 0]
-  <PRIVATE_KEY>  [env: PRIVATE_KEY=]
+  [ARGS]...
 
 Options:
-      --calldata <CALLDATA>                            [default: ]
+      --value <VALUE>
+          Value to send in wei [default: 0]
+      --calldata <CALLDATA>
+          [default: ]
       --chain-id <CHAIN_ID>
+
       --nonce <NONCE>
+
       --gas-limit <GAS_LIMIT>
+
       --gas-price <MAX_FEE_PER_GAS>
+
       --priority-gas-price <MAX_PRIORITY_FEE_PER_GAS>
-      --rpc-url <RPC_URL>                              [env: RPC_URL=] [default: http://localhost:8545]
-      -b                                               Do not wait for the transaction receipt
-      --explorer-url                                   Display transaction URL in the explorer.
-  -h, --help                                           Print help
-```
+
+  -c, --cast
+          Send the request asynchronously.
+  -s, --silent
+          Display only the tx hash.
+      --explorer-url
+          Display transaction URL in the explorer.
+  -k, --private-key <PRIVATE_KEY>
+          [env: PRIVATE_KEY=]
+      --rpc-url <RPC_URL>
+          [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help
+          Print help
 
 ### `rex call`
 
 ```Shell
 Make a call to a contract
 
-Usage: rex call [OPTIONS] <TO> [CALLDATA] [VALUE]  -- [SIGNATURE [ARGS]]
+Usage: rex call [OPTIONS] <TO> [ARGS]...
 
 Arguments:
   <TO>
-  [CALLDATA]  [default: ]
-  [VALUE]     Value to send in wei [default: 0]
+  [ARGS]...
 
 Options:
+      --calldata <CALLDATA>                [default: ]
+      --value <VALUE>                      Value to send in wei [default: 0]
       --from <FROM>
       --gas-limit <GAS_LIMIT>
       --max-fee-per-gas <MAX_FEE_PER_GAS>

--- a/cli/README.md
+++ b/cli/README.md
@@ -261,6 +261,7 @@ Options:
           [env: RPC_URL=] [default: http://localhost:8545]
   -h, --help
           Print help
+```
 
 ### `rex call`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -314,11 +314,13 @@ Options:
 ### `rex encode-calldata`
 
 ```Shell
-Usage: rex encode-calldata <SIGNATURE> [ARGUMENTS]
+Encodes calldata
+
+Usage: rex encode-calldata <SIGNATURE> [ARGS]...
 
 Arguments:
   <SIGNATURE>
-  [SIGNATURE]
+  [ARGS]...
 
 Options:
   -h, --help  Print help

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -196,7 +196,7 @@ pub(crate) enum Command {
     #[clap(about = "Encodes calldata")]
     EncodeCalldata {
         signature: String,
-        #[arg(last = true)]
+        #[clap(required = false)]
         args: Vec<String>,
     },
     #[clap(about = "Decodes calldata")]

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -58,6 +58,7 @@ pub struct TransferArgs {
 pub struct SendArgs {
     pub to: Address,
     #[clap(
+        long,
         value_parser = parse_u256,
         default_value = "0",
         required = false,
@@ -96,9 +97,15 @@ pub struct SendArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
+    #[clap(
+        long = "private-key",
+        short = 'k',
+        value_parser = parse_private_key,
+        env = "PRIVATE_KEY",
+        required = false
+    )]
     pub private_key: SecretKey,
-    #[arg(hide = true)]
+    #[clap(required = false)]
     pub _args: Vec<String>,
 }
 
@@ -108,6 +115,7 @@ pub struct CallArgs {
     #[clap(long, value_parser = parse_hex, required = false, default_value = "")]
     pub calldata: Bytes,
     #[clap(
+        long,
         value_parser = parse_u256,
         default_value = "0",
         required = false,
@@ -126,7 +134,7 @@ pub struct CallArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[arg(hide = true)]
+    #[clap(required = false)]
     pub _args: Vec<String>,
 }
 

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -98,7 +98,7 @@ pub struct SendArgs {
     pub explorer_url: bool,
     #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
-    #[arg(last = true, hide = true)]
+    #[arg(hide = true)]
     pub _args: Vec<String>,
 }
 

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -126,7 +126,7 @@ pub struct CallArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[arg(last = true, hide = true)]
+    #[arg(hide = true)]
     pub _args: Vec<String>,
 }
 


### PR DESCRIPTION
**Motivation**

The current interface requires passing function signatures and arguments after a `--`. We want to remove that in order for better ux. Also in the `send` command we need to pass some hex string without flags, this is confusing.

**Description**

- Remove the `last` clap config from the `send`, `call` and `encode-calldata`. This removes the necessity of the `--`.
- Add required long flags in the send command to clarify the parameters

**Examples**

- Now `call` is:
  ```
  rex call [OPTIONS] <TO> [ARGS]
  ``` 
  Example:
  ```
  rex call 0xffffffffffffffffffffffffffffffffffffffff "myFunction()"
  ``` 
  or
  ```
  rex call 0xffffffffffffffffffffffffffffffffffffffff "myFunction2(uint256)" 42 --value 4242 --rpc-url http://localhost:8545
  ```

- Now `send` is:
  ```
  rex send [OPTIONS] <TO> [ARGS]
  ```
  Example:
  ```
  rex send 0xffffffffffffffffffffffffffffffffffffffff "someFunction()" --private-key 0x0101010101010101011010101010101010101010101010101010101010101010
  ```
  or: 
  ```
  rex send 0xffffffffffffffffffffffffffffffffffffffff "someFunction2(bool)" true -k 0x0101010101010101011010101010101010101010101010101010101010101010 --value 4242 --rpc-url http://localhost:8545
  ```
- `encode-calldata` is:
  ```
  rex encode-calldata <SIGNATURE> [ARGS]
  ```
  Example:
  ```
  rex encode-calldata "otherFunction()"
  ```
  or:
  ```
  rex encode-calldata "otherFunction2(bytes)" "42424242424242"
  ```
Closes #177 

