### PR TITLE
feat(ci): report to testchannel when manually triggered

### DIFF
--- a/.github/workflows/daily_reports.yml
+++ b/.github/workflows/daily_reports.yml
@@ -153,11 +153,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check if any job failed
+        env:
+          SLACK_WEBHOOK: >
+            ${{ github.event_name == 'workflow_dispatch'
+              && secrets.TEST_CHANNEL_SLACK
+              || secrets.ETHREX_L2_SLACK_WEBHOOK
+            }}
         run: |
           if [ "${{ needs.sdk-integration-test.result }}" != "success" ]; then
-            sh .github/scripts/publish_report.sh ${{ secrets.ETHREX_L2_SLACK_WEBHOOK }} "Rex SDK is not working with the latest ethrex version."
+            sh .github/scripts/publish_report.sh "$SLACK_WEBHOOK" "Rex SDK is not working with the latest ethrex version."
           fi
           if [ "${{ needs.cli-integration-test.result }}" != "success" ]; then
-            sh .github/scripts/publish_report.sh ${{ secrets.ETHREX_L2_SLACK_WEBHOOK }} "Rex CLI is not working with the latest ethrex version."
+            sh .github/scripts/publish_report.sh "$SLACK_WEBHOOK" "Rex CLI is not working with the latest ethrex version."
           fi
           echo "Sending Results" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
**Motivation**

We want to prevent spamming our L2 Slack channel when the workflow is manually triggered.

**Description**

Switches channels depending on whether the workflow is manually triggered or not.


Closes None

