### PR TITLE
fix(ci): bump ethrex version in integration tests

### DIFF
--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -39,7 +39,7 @@ jobs:
           cd ..
           git clone https://github.com/lambdaclass/ethrex.git
           cd ethrex
-          git checkout 187e8c27f9b9a22948cd82b0b3f79866c16ac489
+          git checkout v0.0.4-alpha
           echo "ethrex installed successfully"
 
       # also creates empty verification keys (as workflow runs with exec backend)
@@ -87,7 +87,6 @@ jobs:
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test --package rex-sdk --test tests -- --nocapture --test-threads=1
           killall ethrex_prover -s SIGINT
 
-
   cli-integration-test:
     name: Integration Test - CLI
     runs-on: ubuntu-latest
@@ -114,7 +113,7 @@ jobs:
           cd ..
           git clone https://github.com/lambdaclass/ethrex.git
           cd ethrex
-          git checkout 187e8c27f9b9a22948cd82b0b3f79866c16ac489
+          git checkout v0.0.4-alpha
           echo "ethrex installed successfully"
 
       # also creates empty verification keys (as workflow runs with exec backend)
@@ -164,7 +163,7 @@ jobs:
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test --package rex --test tests -- --nocapture --test-threads=1
           killall ethrex_prover -s SIGINT
 
-# The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
+  # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:
     # "Integration Test" is a required check, don't change the name
     name: Integration Test

--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -49,15 +49,12 @@ jobs:
           make build-prover
           mkdir -p prover/zkvm/interface/sp1/out && touch prover/zkvm/interface/sp1/out/riscv32im-succinct-zkvm-vk
 
-      - name: Build L1 docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ../ethrex/
-          file: ../ethrex/crates/blockchain/dev/Dockerfile
-          tags: ethrex_dev:latest
-          push: false
+      - name: Start L1 docker image
+        run: |
+          cd  ../ethrex/crates/l2
+          docker compose -f docker-compose.yaml up --detach ethrex_l1
 
-      - name: Start L1 & Deploy contracts
+      - name: Deploy contracts
         run: |
           cd  ../ethrex/crates/l2
           touch .env
@@ -67,7 +64,7 @@ jobs:
           ETHREX_DEPLOYER_SP1_CONTRACT_ADDRESS=0x00000000000000000000000000000000000000aa \
           ETHREX_DEPLOYER_RISC0_CONTRACT_ADDRESS=0x00000000000000000000000000000000000000aa \
           ETHREX_L2_VALIDIUM=false \
-          docker compose -f docker-compose-l2.yaml up contract_deployer
+          docker compose -f docker-compose.yaml up contract_deployer
 
       - name: Start Sequencer
         run: |
@@ -75,7 +72,7 @@ jobs:
           CI_ETHREX_WORKDIR=/usr/local/bin \
           ETHREX_L2_VALIDIUM=false \
           ETHREX_WATCHER_BLOCK_DELAY=0 \
-          docker compose -f docker-compose-l2.yaml up --detach ethrex_l2
+          docker compose -f docker-compose.yaml up --detach ethrex_l2
 
       - name: Run test
         run: |
@@ -123,15 +120,12 @@ jobs:
           make build-prover
           mkdir -p prover/zkvm/interface/sp1/out && touch prover/zkvm/interface/sp1/out/riscv32im-succinct-zkvm-vk
 
-      - name: Build L1 docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ../ethrex/
-          file: ../ethrex/crates/blockchain/dev/Dockerfile
-          tags: ethrex_dev:latest
-          push: false
+      - name: Start L1 docker image
+        run: |
+          cd  ../ethrex/crates/l2
+          docker compose -f docker-compose.yaml up --detach ethrex_l1
 
-      - name: Start L1 & Deploy contracts
+      - name: Deploy contracts
         run: |
           cd  ../ethrex/crates/l2
           touch .env
@@ -141,7 +135,7 @@ jobs:
           ETHREX_DEPLOYER_SP1_CONTRACT_ADDRESS=0x00000000000000000000000000000000000000aa \
           ETHREX_DEPLOYER_RISC0_CONTRACT_ADDRESS=0x00000000000000000000000000000000000000aa \
           ETHREX_L2_VALIDIUM=false \
-          docker compose -f docker-compose-l2.yaml up contract_deployer
+          docker compose -f docker-compose.yaml up contract_deployer
 
       - name: Start Sequencer
         run: |
@@ -149,7 +143,7 @@ jobs:
           CI_ETHREX_WORKDIR=/usr/local/bin \
           ETHREX_L2_VALIDIUM=false \
           ETHREX_WATCHER_BLOCK_DELAY=0 \
-          docker compose -f docker-compose-l2.yaml up --detach ethrex_l2
+          docker compose -f docker-compose.yaml up --detach ethrex_l2
 
       - name: Run test
         run: |


### PR DESCRIPTION
**Motivation**

We were using an old ethrex version in our CI integration tests

**Description**

Updates CI ethrex version

Closes None

