### PR TITLE
feat(sdk): estimate gas when callling deposit_through_contract_call

### DIFF
--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -319,11 +319,9 @@ impl Command {
                     .await?
                 } else {
                     println!("Depositing {amount} from {to:#x} to bridge");
-                    // TODO: estimate l1 gas price
                     deposit_through_contract_call(
                         amount,
                         to,
-                        21000 * 100,
                         &private_key,
                         bridge_address,
                         &eth_client,

--- a/sdk/src/l2/deposit.rs
+++ b/sdk/src/l2/deposit.rs
@@ -24,7 +24,6 @@ pub async fn deposit_through_transfer(
 pub async fn deposit_through_contract_call(
     amount: U256,
     to: Address,
-    l1_gas_limit: u64,
     depositor_private_key: &SecretKey,
     bridge_address: Address,
     eth_client: &EthClient,
@@ -47,7 +46,6 @@ pub async fn deposit_through_contract_call(
             Overrides {
                 from: Some(l1_from),
                 value: Some(amount),
-                gas_limit: Some(l1_gas_limit),
                 max_fee_per_gas: Some(gas_price),
                 max_priority_fee_per_gas: Some(gas_price),
                 ..Default::default()

--- a/sdk/tests/tests.rs
+++ b/sdk/tests/tests.rs
@@ -350,7 +350,6 @@ async fn test_deposit_through_contract_call(
     let deposit_tx_hash = deposit_through_contract_call(
         deposit_value,
         deposit_recipient_address,
-        21000 * 100,
         depositor_private_key,
         bridge_address,
         eth_client,


### PR DESCRIPTION
**Motivation**

We were not estimating gas when doing a deposit, leading to a loss of funds when the tx failed

**Description**

- If we don't pass gas_limit as an override the ethrex-sdk will estimate the necessary gas using eth_estimateGas


