### PR TITLE
fix(sdk): silent deploy

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{ArgAction, Parser, Subcommand};
 use ethrex_common::types::TxType;
 use ethrex_common::{Address, Bytes, H256, H520};
 use ethrex_l2_common::calldata::Value;
-use ethrex_l2_rpc::clients::{deploy, send_generic_transaction};
+use ethrex_l2_rpc::clients::send_generic_transaction;
 use ethrex_l2_rpc::signer::{LocalSigner, Signer};
 use ethrex_rpc::EthClient;
 use ethrex_rpc::clients::Overrides;
@@ -23,7 +23,7 @@ use rex_sdk::create::{
 };
 use rex_sdk::sign::{get_address_from_message_and_signature, sign_hash};
 use rex_sdk::utils::to_checksum_address;
-use rex_sdk::{balance_in_eth, transfer, wait_for_transaction_receipt};
+use rex_sdk::{balance_in_eth, deploy, transfer, wait_for_transaction_receipt};
 use secp256k1::SecretKey;
 use std::io::{self, Write};
 
@@ -558,6 +558,7 @@ impl Command {
                         max_priority_fee_per_gas: args.max_priority_fee_per_gas,
                         ..Default::default()
                     },
+                    true,
                 )
                 .await?;
 

--- a/sdk/tests/tests.rs
+++ b/sdk/tests/tests.rs
@@ -1,9 +1,6 @@
 use ethrex_common::{Address, Bytes, H160, H256, U256};
 use ethrex_l2_common::calldata::Value;
-use ethrex_l2_rpc::{
-    clients::deploy,
-    signer::{LocalSigner, Signer},
-};
+use ethrex_l2_rpc::signer::{LocalSigner, Signer};
 use ethrex_rpc::{
     EthClient,
     clients::Overrides,
@@ -16,6 +13,7 @@ use ethrex_sdk::{L1ToL2TransactionData, calldata::encode_calldata, send_l1_to_l2
 use keccak_hash::keccak;
 use rex_sdk::{
     client::eth::get_address_from_secret_key,
+    deploy,
     l2::{
         deposit::{deposit_through_contract_call, deposit_through_transfer},
         privileged_transaction_data::PrivilegedTransactionData,
@@ -827,6 +825,7 @@ async fn test_deploy(
         &deployer,
         init_code.to_vec().into(),
         Overrides::default(),
+        true,
     )
     .await?;
 


### PR DESCRIPTION
**Motivation**

In #192, our `deploy()` function was replaced by the ethrex version. The problem is that the ethrex implementation internally calls [wait_for_transaction_receipt()](https://github.com/lambdaclass/ethrex/blob/1d9fdf41e0e549db862112eb8e618eff85220f2a/crates/l2/sdk/src/sdk.rs#L86), which spams `stdout`.

**Description**

Restore our `deploy()` implementation until the ethrex one can be silenced.

Closes None

