### PR TITLE
refactor(cli): general ux improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Commands:
   chain-id          Get the network's chain id.
   code              Returns code at a given address
   create-address    Compute contract address given the deployer address and nonce.
+  create2-address   Compute contract address for CREATE2 deployments.
   deploy            Deploy a contract
-  hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h]
+  hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h, keccak]
   l2                L2 specific commands.
   nonce             Get the account's nonce. [aliases: n]
   receipt           Get the transaction's receipt. [aliases: r]
@@ -61,6 +62,9 @@ Commands:
   transaction       Get the transaction's info. [aliases: tx, t]
   transfer          Transfer funds to another wallet.
   verify-signature  Verify if the signature of a message was made by an account
+  encode-calldata   Encodes calldata
+  decode-calldata   Decodes calldata
+  authorize         Authorize a delegated account
   help              Print this message or the help of the given subcommand(s)
 
 Options:

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,18 +4,28 @@
 - [How to run](#how-to-run)
 - [Commands](#commands)
   - [`rex address`](#rex-address)
-  - [`rex hash`](#rex-hash)
-  - [`rex receipt`](#rex-receipt)
-  - [`rex transaction`](#rex-transaction)
+  - [`rex autocomplete`](#rex-autocomplete)
   - [`rex balance`](#rex-balance)
-  - [`rex nonce`](#rex-nonce)
   - [`rex block-number`](#rex-block-number)
-  - [`rex signer`](#rex-signer)
-  - [`rex chain-id`](#rex-chain-id)
-  - [`rex transfer`](#rex-transfer)
-  - [`rex send`](#rex-send)
   - [`rex call`](#rex-call)
+  - [`rex chain-id`](#rex-chain-id)
+  - [`rex code`](#rex-code)
+  - [`rex create-address`](#rex-create-address)
+  - [`rex create2-address`](#rex-create2-address)
+  - [`rex decode-calldata`](#rex-decode-calldata)
   - [`rex deploy`](#rex-deploy)
+  - [`rex encode-calldata`](#rex-encode-calldata)
+  - [`rex hash`](#rex-hash)
+  - [`rex help`](#rex-help)
+  - [`rex l2`](#rex-l2)
+  - [`rex nonce`](#rex-nonce)
+  - [`rex receipt`](#rex-receipt)
+  - [`rex send`](#rex-send)
+  - [`rex sign`](#rex-sign)
+  - [`rex signer`](#rex-signer)
+  - [`rex transaction`](#rex-transaction)
+  - [`rex transfer`](#rex-transfer)
+  - [`rex verify-signature`](#rex-verify-signature)
 - [Examples](#examples)
 
 
@@ -45,7 +55,7 @@ Commands:
   chain-id          Get the network's chain id.
   code              Returns code at a given address
   create-address    Compute contract address given the deployer address and nonce.
-  create2-address   Compute contract address with CREATE2 opcode.
+  create2-address   
   deploy            Deploy a contract
   hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h]
   l2                L2 specific commands.
@@ -57,6 +67,8 @@ Commands:
   transaction       Get the transaction's info. [aliases: tx, t]
   transfer          Transfer funds to another wallet.
   verify-signature  Verify if the signature of a message was made by an account
+  encode-calldata   Encodes calldata
+  decode-calldata   Decodes calldata
   help              Print this message or the help of the given subcommand(s)
 
 Options:
@@ -74,14 +86,226 @@ Get either the account's address from private key, the zero address, or a random
 Usage: rex address [OPTIONS]
 
 Options:
-      --from-private-key <FROM_PRIVATE_KEY>
-          The private key to derive the address from. [env: PRIVATE_KEY=]
-  -z, --zero
-          The zero address.
-  -r, --random
-          A random address.
+      --private-key <PRIVATE_KEY>  The private key to derive the address from. [env: PRIVATE_KEY=]
+  -z, --zero                       The zero address.
+  -r, --random                     A random address.
+  -h, --help                       Print help
+```
+
+### `rex autocomplete`
+
+```Shell
+Generate shell completion scripts.
+
+Usage: rex autocomplete <COMMAND>
+
+Commands:
+  generate  Generate autocomplete shell script.
+  install   Generate and install autocomplete shell script.
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+### `rex balance`
+
+```Shell
+Get the account's balance info.
+
+Usage: rex balance [OPTIONS] <ACCOUNT>
+
+Arguments:
+  <ACCOUNT>
+
+Options:
+      --token <TOKEN_ADDRESS>  Specify the token address, the ETH is used as default.
+      --eth                    Display the balance in ETH.
+      --rpc-url <RPC_URL>      [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help                   Print help
+```
+
+### `rex block-number`
+
+```Shell
+Get the current block_number.
+
+Usage: rex block-number [OPTIONS]
+
+Options:
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
+```
+
+### `rex call`
+
+```Shell
+Make a call to a contract
+
+Usage: rex call [OPTIONS] <TO> [ARGS]...
+
+Arguments:
+  <TO>
+  [ARGS]...
+
+Options:
+      --calldata <CALLDATA>                [default: ]
+      --value <VALUE>                      Value to send in wei [default: 0]
+      --from <FROM>
+      --gas-limit <GAS_LIMIT>
+      --max-fee-per-gas <MAX_FEE_PER_GAS>
+      --explorer-url                       Display transaction URL in the explorer.
+      --rpc-url <RPC_URL>                  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help                               Print help
+```
+
+### `rex chain-id`
+
+```Shell
+Get the network's chain id.
+
+Usage: rex chain-id [OPTIONS]
+
+Options:
+      --hex                Display the chain id as a hex-string.
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
+```
+
+### `rex code`
+
+```Shell
+Returns code at a given address
+
+Usage: rex code [OPTIONS] <ADDRESS>
+
+Arguments:
+  <ADDRESS>
+
+Options:
+  -B, --block <BLOCK>      defaultBlock parameter: can be integer block number, 'earliest', 'finalized', 'safe', 'latest' or 'pending' [default: latest]
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
+```
+
+### `rex create-address`
+
+```Shell
+Compute contract address given the deployer address and nonce.
+
+Usage: rex create-address [OPTIONS] <DEPLOYER>
+
+Arguments:
+  <DEPLOYER>  Deployer address.
+
+Options:
+  -n, --nonce <NONCE>      Deployer Nonce. Latest by default.
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
+```
+
+### `rex create2-address`
+
+```Shell
+Usage: rex create2-address [OPTIONS]
+
+Options:
+  -d, --deployer <DEPLOYER>
+          Deployer address. Default is Mainnet Deterministic Deployer [default: 0x4e59b44847b379578588920cA78FbF26c0B4956C]
+  -i, --init-code <INIT_CODE>
+          Initcode of the contract to deploy.
+      --init-code-hash <INIT_CODE_HASH>
+          Hash of the initcode (keccak256).
+  -s, --salt <SALT>
+          Salt for CREATE2 opcode
+      --begins <BEGINS>
+          Address must begin with this hex prefix.
+      --ends <ENDS>
+          Address must end with this hex suffix.
+      --contains <CONTAINS>
+          Address must contain this hex substring.
+      --case-sensitive
+          Make the address search case sensitive when using begins, ends, or contains.
+      --threads <THREADS>
+          Number of threads to use for brute-forcing. Defaults to the number of logical CPUs. [default: 8]
   -h, --help
           Print help
+```
+
+### `rex decode-calldata`
+
+```Shell
+Decodes calldata
+
+Usage: rex decode-calldata <SIGNATURE> <DATA>
+
+Arguments:
+  <SIGNATURE>
+  <DATA>
+
+Options:
+  -h, --help  Print help
+```
+
+### `rex deploy`
+
+```Shell
+Deploy a contract
+
+Usage: rex deploy [OPTIONS] <--bytecode <BYTECODE>|--contract-path <CONTRACT_PATH>>
+
+Options:
+      --bytecode <BYTECODE>
+
+      --value <VALUE>
+          Value to send in wei [default: 0]
+      --chain-id <CHAIN_ID>
+
+      --nonce <NONCE>
+
+      --gas-limit <GAS_LIMIT>
+
+      --gas-price <MAX_FEE_PER_GAS>
+
+      --priority-gas-price <MAX_PRIORITY_FEE_PER_GAS>
+
+      --print-address
+
+  -c, --cast
+          Send the request asynchronously.
+  -s, --silent
+          Display only the tx hash.
+      --explorer-url
+          Display transaction URL in the explorer.
+      --private-key <PRIVATE_KEY>
+          [env: PRIVATE_KEY=]
+      --contract-path <CONTRACT_PATH>
+          Path to the Solidity file to compile and deploy
+      --remappings <REMAPPINGS>
+          Comma-separated remappings (e.g. '@openzeppelin/contracts=https://github.com/OpenZeppelin/openzeppelin-contracts.git,@custom=path/to/custom')
+      --keep-deps
+          Remove downloaded dependencies after compilation
+      --salt <SALT>
+          Salt for deploying CREATE2 contracts. If it is provided, the contract will be deployed using CREATE2.
+      --rpc-url <RPC_URL>
+          [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help
+          Print help
+```
+
+### `rex encode-calldata`
+
+```Shell
+Encodes calldata
+
+Usage: rex encode-calldata <SIGNATURE> [ARGS]...
+
+Arguments:
+  <SIGNATURE>
+  [ARGS]...
+
+Options:
+  -h, --help  Print help
 ```
 
 ### `rex hash`
@@ -99,51 +323,67 @@ Options:
   -h, --help           Print help
 ```
 
-### `rex receipt`
+### `rex help`
 
 ```Shell
-Get the transaction's receipt.
+Usage: rex <COMMAND>
 
-Usage: rex receipt <TX_HASH> [RPC_URL]
+Commands:
+  address           Get either the account's address from private key, the zero address, or a random address [aliases: addr, a]
+  autocomplete      Generate shell completion scripts.
+  balance           Get the account's balance info. [aliases: bal, b]
+  block-number      Get the current block_number. [aliases: bl]
+  call              Make a call to a contract
+  chain-id          Get the network's chain id.
+  code              Returns code at a given address
+  create-address    Compute contract address given the deployer address and nonce.
+  create2-address   
+  deploy            Deploy a contract
+  hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h]
+  l2                L2 specific commands.
+  nonce             Get the account's nonce. [aliases: n]
+  receipt           Get the transaction's receipt. [aliases: r]
+  send              Send a transaction
+  sign              Sign a message with a private key
+  signer            
+  transaction       Get the transaction's info. [aliases: tx, t]
+  transfer          Transfer funds to another wallet.
+  verify-signature  Verify if the signature of a message was made by an account
+  encode-calldata   Encodes calldata
+  decode-calldata   Decodes calldata
+  help              Print this message or the help of the given subcommand(s)
 
-Arguments:
-  <TX_HASH>
-  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+### `rex l2`
+
+```Shell
+L2 specific commands.
+
+Usage: rex l2 <COMMAND>
+
+Commands:
+  balance         Get the account's balance on L2. [aliases: bal, b]
+  block-number    Get the current block_number. [aliases: bl]
+  call            Make a call to a contract
+  chain-id        Get the network's chain id.
+  claim-withdraw  Finalize a pending withdrawal.
+  deploy          Deploy a contract
+  deposit         Deposit funds into some wallet.
+  nonce           Get the account's nonce. [aliases: n]
+  receipt         Get the transaction's receipt. [aliases: r]
+  send            Send a transaction
+  transaction     Get the transaction's info. [aliases: tx, t]
+  transfer        Transfer funds to another wallet.
+  withdraw        Withdraw funds from the wallet.
+  message-proof   Get the merkle proof of a L1MessageProof.
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
-```
-
-### `rex transaction`
-
-```Shell
-Get the transaction's info.
-
-Usage: rex transaction <TX_HASH> [RPC_URL]
-
-Arguments:
-  <TX_HASH>
-  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]
-
-Options:
-  -h, --help  Print help
-```
-
-### `rex balance`
-
-```Shell
-Get the account's balance info.
-
-Usage: rex balance [OPTIONS] <ACCOUNT> [RPC_URL]
-
-Arguments:
-  <ACCOUNT>
-  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]
-
-Options:
-      --token <TOKEN_ADDRESS>  Specify the token address, the ETH is used as default.
-      --eth                    Display the balance in ETH.
-  -h, --help                   Print help
 ```
 
 ### `rex nonce`
@@ -151,77 +391,29 @@ Options:
 ```Shell
 Get the account's nonce.
 
-Usage: rex nonce <ACCOUNT> [RPC_URL]
+Usage: rex nonce [OPTIONS] <ACCOUNT>
 
 Arguments:
   <ACCOUNT>
-  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]
 
 Options:
-  -h, --help  Print help
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
 ```
 
-### `rex block-number`
+### `rex receipt`
 
 ```Shell
-Get the current block_number.
+Get the transaction's receipt.
 
-Usage: rex block-number [RPC_URL]
-
-Arguments:
-  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]
-
-Options:
-  -h, --help  Print help
-```
-
-### `rex signer`
-
-```Shell
-Usage: rex signer <MESSAGE> <SIGNATURE>
+Usage: rex receipt [OPTIONS] <TX_HASH>
 
 Arguments:
-  <MESSAGE>
-  <SIGNATURE>
+  <TX_HASH>
 
 Options:
-  -h, --help  Print help
-```
-
-### `rex chain-id`
-
-```Shell
-Get the network's chain id.
-
-Usage: rex chain-id [OPTIONS] [RPC_URL]
-
-Arguments:
-  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]
-
-Options:
-  -h, --hex   Display the chain id as a hex-string.
-  -h, --help  Print help
-```
-
-### `rex transfer`
-
-```Shell
-Transfer funds to another wallet.
-
-Usage: rex transfer [OPTIONS] <AMOUNT> <TO> <PRIVATE_KEY> [RPC_URL]
-
-Arguments:
-  <AMOUNT>
-  <TO>
-  <PRIVATE_KEY>  [env: PRIVATE_KEY=]
-  [RPC_URL]      [env: RPC_URL=] [default: http://localhost:8545]
-
-Options:
-      --token <TOKEN_ADDRESS>
-      --nonce <NONCE>
-  -b                           Do not wait for the transaction receipt
-      --explorer-url           Display transaction URL in the explorer.
-  -h, --help                   Print help
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
 ```
 
 ### `rex send`
@@ -264,77 +456,82 @@ Options:
           Print help
 ```
 
-### `rex call`
+### `rex sign`
 
 ```Shell
-Make a call to a contract
+Sign a message with a private key
 
-Usage: rex call [OPTIONS] <TO> [ARGS]...
+Usage: rex sign --private-key <PRIVATE_KEY> <MSG>
 
 Arguments:
-  <TO>
-  [ARGS]...
+  <MSG>  Message to be signed with the private key.
 
 Options:
-      --calldata <CALLDATA>                [default: ]
-      --value <VALUE>                      Value to send in wei [default: 0]
-      --from <FROM>
-      --gas-limit <GAS_LIMIT>
-      --max-fee-per-gas <MAX_FEE_PER_GAS>
-      --explorer-url                       Display transaction URL in the explorer.
-      --rpc-url <RPC_URL>                  [env: RPC_URL=] [default: http://localhost:8545]
-  -h, --help                               Print help
+      --private-key <PRIVATE_KEY>  The private key to sign the message. [env: PRIVATE_KEY=]
+  -h, --help                       Print help
 ```
 
-### `rex deploy`
+### `rex signer`
 
 ```Shell
-Deploy a contract
-
-Usage: rex deploy [OPTIONS] <BYTECODE> [VALUE] <PRIVATE_KEY> -- [SIGNATURE [ARGS]]
+Usage: rex signer <MESSAGE> <SIGNATURE>
 
 Arguments:
-  <BYTECODE>
-  [VALUE]        Value to send in wei [default: 0]
-  <PRIVATE_KEY>  [env: PRIVATE_KEY=]
-  
-
-Options:
-      --chain-id <CHAIN_ID>
-      --nonce <NONCE>
-      --gas-limit <GAS_LIMIT>
-      --gas-price <MAX_FEE_PER_GAS>
-      --priority-gas-price <MAX_PRIORITY_FEE_PER_GAS>
-      --print-address                                  Only print the contract address
-      --rpc-url                                        [env: RPC_URL=] [default: http://localhost:8545]
-  -b                                                   Do not wait for the transaction receipt
-      --explorer-url                                   Display transaction URL in the explorer.
-  -h, --help                                           Print help
-```
-
-### `rex encode-calldata`
-
-```Shell
-Encodes calldata
-
-Usage: rex encode-calldata <SIGNATURE> [ARGS]...
-
-Arguments:
+  <MESSAGE>
   <SIGNATURE>
-  [ARGS]...
 
 Options:
   -h, --help  Print help
 ```
 
-### `rex decode-calldata`
+### `rex transaction`
 
 ```Shell
-Usage: rex decode-calldata <SIGNATURE> <CALLDATA>
+Get the transaction's info.
+
+Usage: rex transaction [OPTIONS] <TX_HASH>
 
 Arguments:
+  <TX_HASH>
+
+Options:
+      --rpc-url <RPC_URL>  [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help               Print help
+```
+
+### `rex transfer`
+
+```Shell
+Transfer funds to another wallet.
+
+Usage: rex transfer [OPTIONS] <AMOUNT> <TO>
+
+Arguments:
+  <AMOUNT>
+  <TO>
+
+Options:
+      --token <TOKEN_ADDRESS>
+      --nonce <NONCE>
+  -c, --cast                       Send the request asynchronously.
+  -s, --silent                     Display only the tx hash.
+      --explorer-url               Display transaction URL in the explorer.
+      --private-key <PRIVATE_KEY>  [env: PRIVATE_KEY=]
+      --rpc-url <RPC_URL>          [env: RPC_URL=] [default: http://localhost:8545]
+  -h, --help                       Print help
+```
+
+### `rex verify-signature`
+
+```Shell
+Verify if the signature of a message was made by an account
+
+Usage: rex verify-signature <MESSAGE> <SIGNATURE> <ADDRESS>
+
+Arguments:
+  <MESSAGE>
   <SIGNATURE>
-  <CALLDATA>
+  <ADDRESS>
 
 Options:
   -h, --help  Print help

--- a/cli/README.md
+++ b/cli/README.md
@@ -55,7 +55,7 @@ Commands:
   chain-id          Get the network's chain id.
   code              Returns code at a given address
   create-address    Compute contract address given the deployer address and nonce.
-  create2-address   
+  create2-address   Compute contract address with CREATE2 opcode.
   deploy            Deploy a contract
   hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h]
   l2                L2 specific commands.
@@ -337,7 +337,7 @@ Commands:
   chain-id          Get the network's chain id.
   code              Returns code at a given address
   create-address    Compute contract address given the deployer address and nonce.
-  create2-address   
+  create2-address   Compute contract address with CREATE2 opcode.
   deploy            Deploy a contract
   hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h]
   l2                L2 specific commands.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -54,10 +54,10 @@ pub(crate) enum Command {
     )]
     Address {
         #[arg(long, value_parser = parse_private_key, conflicts_with_all = ["zero", "random"], required_unless_present_any = ["zero", "random"], env = "PRIVATE_KEY", help = "The private key to derive the address from.")]
-        from_private_key: Option<SecretKey>,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "random"], required_unless_present_any = ["from_private_key", "random"], help = "The zero address.")]
+        private_key: Option<SecretKey>,
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["private_key", "random"], required_unless_present_any = ["private_key", "random"], help = "The zero address.")]
         zero: bool,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "zero"], required_unless_present_any = ["from_private_key", "zero"], help = "A random address.")]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["private_key", "zero"], required_unless_present_any = ["private_key", "zero"], help = "A random address.")]
         random: bool,
     },
     #[clap(subcommand, about = "Generate shell completion scripts.")]
@@ -79,12 +79,12 @@ pub(crate) enum Command {
             help = "Display the balance in ETH."
         )]
         eth: bool,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Get the current block_number.", visible_alias = "bl")]
     BlockNumber {
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Make a call to a contract")]
@@ -102,7 +102,7 @@ pub(crate) enum Command {
             help = "Display the chain id as a hex-string."
         )]
         hex: bool,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Returns code at a given address")]
@@ -116,7 +116,7 @@ pub(crate) enum Command {
             help = "defaultBlock parameter: can be integer block number, 'earliest', 'finalized', 'safe', 'latest' or 'pending'"
         )]
         block: String,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Compute contract address given the deployer address and nonce.")]
@@ -215,13 +215,13 @@ pub(crate) enum Command {
     #[clap(about = "Get the account's nonce.", visible_aliases = ["n"])]
     Nonce {
         account: Address,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Get the transaction's receipt.", visible_alias = "r")]
     Receipt {
         tx_hash: H256,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Send a transaction")]
@@ -235,7 +235,7 @@ pub(crate) enum Command {
     Sign {
         #[arg(value_parser = parse_hex, help = "Message to be signed with the private key.")]
         msg: Bytes,
-        #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY", help = "The private key to sign the message.")]
+        #[arg(long, value_parser = parse_private_key, env = "PRIVATE_KEY", help = "The private key to sign the message.")]
         private_key: SecretKey,
     },
     Signer {
@@ -247,14 +247,14 @@ pub(crate) enum Command {
     #[clap(about = "Get the transaction's info.", visible_aliases = ["tx", "t"])]
     Transaction {
         tx_hash: H256,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Transfer funds to another wallet.")]
     Transfer {
         #[clap(flatten)]
         args: TransferArgs,
-        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Verify if the signature of a message was made by an account")]
@@ -453,11 +453,11 @@ impl Command {
                 println!("{nonce}");
             }
             Command::Address {
-                from_private_key,
+                private_key,
                 zero,
                 random,
             } => {
-                let address = if let Some(private_key) = from_private_key {
+                let address = if let Some(private_key) = private_key {
                     get_address_from_secret_key(&private_key).map_err(|e| eyre::eyre!(e))?
                 } else if zero {
                     Address::zero()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -384,7 +384,57 @@ impl Command {
                     .await?
                     .ok_or(eyre::Error::msg("Not found"))?;
 
-                println!("{:x?}", receipt.tx_info);
+                let to = match receipt.tx_info.to {
+                    Some(addr) => format!("0x{:x}", addr),
+                    None => "".to_string(),
+                };
+                let contract_address = match receipt.tx_info.contract_address {
+                    Some(addr) => format!("0x{:x}", addr),
+                    None => "".to_string(),
+                };
+                let blob_gas_price = match receipt.tx_info.blob_gas_price {
+                    Some(price) => format!("{}", price),
+                    None => "".to_string(),
+                };
+                let blob_gas_used = match receipt.tx_info.blob_gas_used {
+                    Some(used) => format!("{}", used),
+                    None => "".to_string(),
+                };
+
+                println!("Receipt for transaction 0x{:x}:", tx_hash);
+                println!(
+                    "  transaction index:    {}",
+                    receipt.tx_info.transaction_index
+                );
+                println!("  from:                 0x{:x}", receipt.tx_info.from);
+                println!("  to:                   {}", to);
+                println!("  gas used:             {}", receipt.tx_info.gas_used);
+                println!(
+                    "  effective gas price:  {}",
+                    receipt.tx_info.effective_gas_price
+                );
+                println!("  contract address:     {}", contract_address);
+                println!("  blob gas price:       {}", blob_gas_price);
+                println!("  blob gas used:        {}", blob_gas_used);
+                println!("  status:               {}", receipt.receipt.status);
+                println!(
+                    "  cumulative gas used:  {}",
+                    receipt.receipt.cumulative_gas_used
+                );
+                println!("  logs bloom:           0x{:x}", receipt.receipt.logs_bloom);
+                println!("  tx type:              {:?}", receipt.receipt.tx_type);
+                println!(
+                    "  block hash:           0x{:x}",
+                    receipt.block_info.block_hash
+                );
+                println!(
+                    "  block number:         {}",
+                    receipt.block_info.block_number
+                );
+                println!(
+                    "  transaction hash:     0x{:x}",
+                    receipt.tx_info.transaction_hash
+                );
             }
             Command::Nonce { account, rpc_url } => {
                 let eth_client = EthClient::new(rpc_url)?;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -732,7 +732,7 @@ fn print_receipt_logs(logs: &[RpcLog]) {
     println!("  logs:");
     for (idx, log) in logs.iter().enumerate() {
         println!(
-            "    [{}] address:        0x{:x}",
+            "    [{}] address:      0x{:x}",
             log.log_index, log.log.address
         );
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -7,6 +7,7 @@ use crate::{
     utils::parse_private_key,
 };
 use clap::{ArgAction, Parser, Subcommand};
+use ethrex_common::types::TxKind;
 use ethrex_common::types::{AuthorizationTupleEntry, TxType};
 use ethrex_common::{Address, Bytes, H256, H520};
 use ethrex_l2_common::calldata::Value;
@@ -17,6 +18,7 @@ use ethrex_rpc::EthClient;
 use ethrex_rpc::clients::Overrides;
 use ethrex_rpc::types::block_identifier::{BlockIdentifier, BlockTag};
 use ethrex_rpc::types::receipt::RpcReceipt;
+use ethrex_rpc::types::transaction::RpcTransaction;
 use ethrex_sdk::calldata::decode_calldata;
 use ethrex_sdk::{build_generic_tx, create2_deploy_from_bytecode, send_generic_transaction};
 use ethrex_sdk::{compile_contract, git_clone};
@@ -386,7 +388,7 @@ impl Command {
                     .await?
                     .ok_or(eyre::Error::msg("Not found"))?;
 
-                println!("{tx:?}");
+                print_transaction(&tx);
             }
             Command::Receipt { tx_hash, rpc_url } => {
                 let eth_client = EthClient::new(rpc_url)?;
@@ -796,6 +798,69 @@ fn print_receipt(receipt: &RpcReceipt) {
             println!();
         }
     }
+}
+
+fn print_transaction(tx: &RpcTransaction) {
+    let inner_tx = &tx.tx;
+
+    // Get from address
+    let from = inner_tx
+        .sender()
+        .map(|addr| format!("0x{:x}", addr))
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    // Get the "to" field
+    let to = match inner_tx.to() {
+        TxKind::Call(addr) => format!("0x{:x}", addr),
+        TxKind::Create => "[contract creation]".to_string(),
+    };
+
+    // Get gas pricing info based on tx type
+    let (gas_price_line, max_fee_line, max_priority_line) = match inner_tx.tx_type() {
+        TxType::Legacy | TxType::EIP2930 => (
+            Some(format!("  gas price:          {}", inner_tx.gas_price())),
+            None,
+            None,
+        ),
+        _ => {
+            let max_fee = inner_tx.max_fee_per_gas().unwrap_or(0);
+            let max_priority = inner_tx.max_priority_fee().unwrap_or(0);
+            (
+                None,
+                Some(format!("  max fee per gas:    {}", max_fee)),
+                Some(format!("  max priority fee:   {}", max_priority)),
+            )
+        }
+    };
+
+    // Input data as hex
+    let input_hex = hex::encode(inner_tx.data());
+    let input_display = if input_hex.is_empty() {
+        "0x".to_string()
+    } else {
+        format!("0x{}", input_hex)
+    };
+
+    println!("Transaction 0x{:x}:", tx.hash);
+    println!("  type:               {}", inner_tx.tx_type());
+    println!("  from:               {}", from);
+    println!("  to:                 {}", to);
+    println!("  value:              {}", inner_tx.value());
+    println!("  nonce:              {}", inner_tx.nonce());
+    println!("  gas limit:          {}", inner_tx.gas_limit());
+    if let Some(line) = gas_price_line {
+        println!("{}", line);
+    }
+    if let Some(line) = max_fee_line {
+        println!("{}", line);
+    }
+    if let Some(line) = max_priority_line {
+        println!("{}", line);
+    }
+    if let Some(chain_id) = inner_tx.chain_id() {
+        println!("  chain id:           {}", chain_id);
+    }
+    println!("  input:              {}", input_display);
 }
 
 fn print_calldata(depth: usize, data: Value) {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -204,7 +204,7 @@ pub(crate) enum Command {
     },
     #[clap(
         about = "Get either the keccak for a given input, the zero hash, the empty string, or a random hash",
-        visible_alias = "h"
+        visible_aliases = ["h", "keccak"]
     )]
     Hash {
         #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random", "string"], required_unless_present_any = ["zero", "random", "string"], help = "The input to hash.")]

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -25,6 +25,7 @@ pub(crate) enum Command {
         #[clap(flatten)]
         args: BalanceArgs,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -34,6 +35,7 @@ pub(crate) enum Command {
     #[clap(about = "Get the current block_number.", visible_alias = "bl")]
     BlockNumber {
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -45,6 +47,7 @@ pub(crate) enum Command {
         #[clap(flatten)]
         args: CallArgs,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -60,7 +63,7 @@ pub(crate) enum Command {
             help = "Display the chain id as a hex-string."
         )]
         hex: bool,
-        #[arg(default_value = "http://localhost:1729", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:1729", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Finalize a pending withdrawal.")]
@@ -95,13 +98,13 @@ pub(crate) enum Command {
             help = "Display only the tx hash."
         )]
         silent: bool,
-        #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+        #[arg(long, value_parser = parse_private_key, env = "PRIVATE_KEY")]
         private_key: SecretKey,
         #[arg(env = "BRIDGE_ADDRESS")]
         bridge_address: Address,
-        #[arg(env = "L1_RPC_URL", default_value = "http://localhost:8545")]
+        #[arg(long, env = "L1_RPC_URL", default_value = "http://localhost:8545")]
         l1_rpc_url: Url,
-        #[arg(env = "RPC_URL", default_value = "http://localhost:1729")]
+        #[arg(long, env = "RPC_URL", default_value = "http://localhost:1729")]
         rpc_url: Url,
     },
     #[clap(about = "Deploy a contract")]
@@ -109,6 +112,7 @@ pub(crate) enum Command {
         #[clap(flatten)]
         args: DeployArgs,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -159,26 +163,27 @@ pub(crate) enum Command {
             help = "Display transaction URL in the explorer."
         )]
         explorer_url: bool,
-        #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+        #[clap(long, value_parser = parse_private_key, env = "PRIVATE_KEY")]
         private_key: SecretKey,
         #[arg(
             env = "BRIDGE_ADDRESS",
             help = "Make sure you are using the correct bridge address before submitting your deposit."
         )]
         bridge_address: Address,
-        #[arg(default_value = "http://localhost:8545", env = "L1_RPC_URL")]
+        #[arg(long, default_value = "http://localhost:8545", env = "L1_RPC_URL")]
         l1_rpc_url: Url,
     },
     #[clap(about = "Get the account's nonce.", visible_aliases = ["n"])]
     Nonce {
         account: Address,
-        #[arg(default_value = "http://localhost:1729", env = "RPC_URL")]
+        #[arg(long, default_value = "http://localhost:1729", env = "RPC_URL")]
         rpc_url: Url,
     },
     #[clap(about = "Get the transaction's receipt.", visible_alias = "r")]
     Receipt {
         tx_hash: H256,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -190,6 +195,7 @@ pub(crate) enum Command {
         #[clap(flatten)]
         args: SendArgs,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -200,6 +206,7 @@ pub(crate) enum Command {
     Transaction {
         tx_hash: H256,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -211,6 +218,7 @@ pub(crate) enum Command {
         #[clap(flatten)]
         args: TransferArgs,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -257,9 +265,10 @@ pub(crate) enum Command {
             help = "Display transaction URL in the explorer."
         )]
         explorer_url: bool,
-        #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+        #[arg(long, value_parser = parse_private_key, env = "PRIVATE_KEY")]
         private_key: SecretKey,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"
@@ -270,6 +279,7 @@ pub(crate) enum Command {
     MessageProof {
         message_tx_hash: H256,
         #[arg(
+            long,
             default_value = "http://localhost:1729",
             env = "RPC_URL",
             help = "L2 RPC URL"

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -176,7 +176,13 @@ pub(crate) enum Command {
             help = "Make sure you are using the correct bridge address before submitting your deposit."
         )]
         bridge_address: Address,
-        #[arg(long, default_value = "http://localhost:8545", env = "L1_RPC_URL")]
+        #[arg(
+            long,
+            alias = "rpc-url",
+            default_value = "http://localhost:8545",
+            env = "L1_RPC_URL",
+            help = "L1 RPC URL where the Bridge will lock the funds"
+        )]
         l1_rpc_url: Url,
     },
     #[clap(about = "Get the account's nonce.", visible_aliases = ["n"])]

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -52,7 +52,7 @@ pub struct TransferArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
+    #[clap(long, value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
 }
 
@@ -100,7 +100,7 @@ pub struct SendArgs {
     )]
     pub explorer_url: bool,
     #[clap(
-        long = "private-key",
+        long,
         short = 'k',
         value_parser = parse_private_key,
         env = "PRIVATE_KEY",
@@ -146,6 +146,7 @@ pub struct DeployArgs {
     #[clap(long, group = "source", value_parser = parse_hex, required = false)]
     pub bytecode: Option<Bytes>,
     #[clap(
+        long,
         value_parser = parse_u256,
         default_value = "0",
         required = false,
@@ -184,7 +185,7 @@ pub struct DeployArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
-    #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
+    #[arg(long, value_parser = parse_private_key, env = "PRIVATE_KEY", required = false)]
     pub private_key: SecretKey,
     #[arg(
         long,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -48,6 +48,27 @@ fn parse_call_args(args: Vec<String>) -> eyre::Result<Option<(String, Vec<Value>
             .next()
             .ok_or(eyre::Error::msg("missing parameter for given signature"))?;
         values.push(match param.as_str() {
+            // Array types must be checked first (before scalar uint/int)
+            _ if param.contains('[') && param.contains(']') => {
+                // Handle fixed-size arrays like uint64[3]
+                let base_type = param.split('[').next().unwrap_or("");
+                let inner = val.trim_start_matches('[').trim_end_matches(']');
+                let elements: Vec<Value> = inner
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| {
+                        if base_type.starts_with("uint") || base_type.starts_with("int") {
+                            Ok(Value::Uint(U256::from_dec_str(s)?))
+                        } else if base_type == "address" {
+                            Ok(Value::Address(Address::from_str(s)?))
+                        } else {
+                            Err(eyre::eyre!("Unsupported array element type: {}", base_type))
+                        }
+                    })
+                    .collect::<eyre::Result<Vec<_>>>()?;
+                Value::FixedArray(elements)
+            }
             "address" => Value::Address(Address::from_str(val)?),
             _ if param.starts_with("uint") => Value::Uint(U256::from_dec_str(val)?),
             _ if param.starts_with("int") => {
@@ -67,8 +88,14 @@ fn parse_call_args(args: Vec<String>) -> eyre::Result<Option<(String, Vec<Value>
                 "false" => Value::Uint(U256::from(0)),
                 _ => Err(eyre::Error::msg("Invalid boolean"))?,
             },
-            "bytes" => Value::Bytes(hex::decode(val)?.into()),
-            _ if param.starts_with("bytes") => Value::FixedBytes(hex::decode(val)?.into()),
+            "bytes" => {
+                let val = val.strip_prefix("0x").unwrap_or(val);
+                Value::Bytes(hex::decode(val)?.into())
+            }
+            _ if param.starts_with("bytes") => {
+                let val = val.strip_prefix("0x").unwrap_or(val);
+                Value::FixedBytes(hex::decode(val)?.into())
+            }
             _ => todo!("type unsupported"),
         });
     }

--- a/cli/tests/tests.rs
+++ b/cli/tests/tests.rs
@@ -10,6 +10,16 @@ use std::{
     time::Duration,
 };
 
+/// Parses a U256 from a string. If the string starts with "0x", it's parsed as hex.
+/// Otherwise, it's parsed as decimal.
+fn parse_u256(s: &str) -> Result<U256, String> {
+    if s.starts_with("0x") || s.starts_with("0X") {
+        U256::from_str(s).map_err(|e| e.to_string())
+    } else {
+        U256::from_dec_str(s).map_err(|e| e.to_string())
+    }
+}
+
 // 0x941e103320615d394a55708be13e45994c7d93b932b064dbcb2b511fe3254e2e
 const DEFAULT_L1_RICH_WALLET_PRIVATE_KEY: H256 = H256([
     0x94, 0x1e, 0x10, 0x33, 0x20, 0x61, 0x5d, 0x39, 0x4a, 0x55, 0x70, 0x8b, 0xe1, 0x3e, 0x45, 0x99,
@@ -142,7 +152,7 @@ async fn test_deposit(
 
     let deposit_tx_receipt = get_receipt(deposit_tx_hash)?;
 
-    let gas_used = U256::from_str(
+    let gas_used = parse_u256(
         deposit_tx_receipt
             .split("gas used:")
             .nth(1)
@@ -154,7 +164,7 @@ async fn test_deposit(
     )
     .unwrap();
 
-    let effective_gas_price = U256::from_str(
+    let effective_gas_price = parse_u256(
         deposit_tx_receipt
             .split("effective gas price:")
             .nth(1)
@@ -493,7 +503,7 @@ async fn test_withdraws(
 
     let mut gas_used_value = U256::zero();
     for receipt in withdraw_claim_txs_receipts {
-        let gas_used = U256::from_str(
+        let gas_used = parse_u256(
             receipt
                 .split("gas used:")
                 .nth(1)
@@ -505,7 +515,7 @@ async fn test_withdraws(
         )
         .unwrap();
 
-        let effective_gas_price = U256::from_str(
+        let effective_gas_price = parse_u256(
             receipt
                 .split("effective gas price:")
                 .nth(1)

--- a/cli/tests/tests.rs
+++ b/cli/tests/tests.rs
@@ -144,10 +144,10 @@ async fn test_deposit(
 
     let gas_used = U256::from_str(
         deposit_tx_receipt
-            .split("gas_used: ")
+            .split("gas used:")
             .nth(1)
             .unwrap()
-            .split(',')
+            .split('\n')
             .next()
             .unwrap()
             .trim(),
@@ -156,10 +156,10 @@ async fn test_deposit(
 
     let effective_gas_price = U256::from_str(
         deposit_tx_receipt
-            .split("effective_gas_price: ")
+            .split("effective gas price:")
             .nth(1)
             .unwrap()
-            .split(',')
+            .split('\n')
             .next()
             .unwrap()
             .trim(),
@@ -495,10 +495,10 @@ async fn test_withdraws(
     for receipt in withdraw_claim_txs_receipts {
         let gas_used = U256::from_str(
             receipt
-                .split("gas_used: ")
+                .split("gas used:")
                 .nth(1)
                 .unwrap()
-                .split(',')
+                .split('\n')
                 .next()
                 .unwrap()
                 .trim(),
@@ -507,10 +507,10 @@ async fn test_withdraws(
 
         let effective_gas_price = U256::from_str(
             receipt
-                .split("effective_gas_price: ")
+                .split("effective gas price:")
                 .nth(1)
                 .unwrap()
-                .split(',')
+                .split('\n')
                 .next()
                 .unwrap()
                 .trim(),

--- a/cli/tests/tests.rs
+++ b/cli/tests/tests.rs
@@ -314,8 +314,9 @@ fn deposit_l2(
     let output = Command::new("rex")
         .arg("l2")
         .arg("deposit")
-        .arg(format!("{amount}"))
+        .arg("--private-key")
         .arg(depositor_private_key.display_secret().to_string())
+        .arg(format!("{amount}"))
         .arg(format!("{bridge_address:#x}"))
         .output()
         .unwrap();
@@ -378,9 +379,10 @@ fn transfer(
     let output = Command::new("rex")
         .arg("l2")
         .arg("transfer")
+        .arg("--private-key")
+        .arg(transferer_private_key.display_secret().to_string())
         .arg(format!("{transfer_value}"))
         .arg(format!("{transfer_recipient_address:#x}"))
-        .arg(transferer_private_key.display_secret().to_string())
         .output()
         .unwrap();
 
@@ -549,8 +551,9 @@ fn withdraw(
     let output = Command::new("rex")
         .arg("l2")
         .arg("withdraw")
-        .arg(format!("{withdraw_amount}"))
+        .arg("--private-key")
         .arg(withdrawer_private_key.display_secret().to_string())
+        .arg(format!("{withdraw_amount}"))
         .output()
         .unwrap();
 
@@ -607,9 +610,10 @@ fn claim_withdraw(
     let output = Command::new("rex")
         .arg("l2")
         .arg("claim-withdraw")
+        .arg("--private-key")
+        .arg(private_key.display_secret().to_string())
         .arg(format!("{amount}"))
         .arg(format!("{tx_hash:#x}"))
-        .arg(private_key.display_secret().to_string())
         .arg(format!("{bridge_address:#x}"))
         .output()
         .unwrap();


### PR DESCRIPTION
> [!IMPORTANT]
> This may break scripts with `deploy`, `transfer`, `sign`, `deposit`, `claim-withdraw` and `withdraw`

## Description

Make overall improvements to rex CLI UX.

### Changes
**Better Output Formatting**
- Add function for readable transaction receipt display after transfer, send, and deploy commands
- Add function for readable transaction output with input data as hex string (instead of raw bytes)
- Add --cast (-c) flag to skip waiting for receipt (send async)
- Add --silent (-s) flag to suppress receipt output

**CLI Ergonomics**
- Change private_key from positional argument to --private-key flag (also reads from PRIVATE_KEY env var)
- Change rpc_url from positional argument to --rpc-url flag with sane defaults
- Add keccak as visible alias for hash command

**Calldata Parsing Improvements**
- Fix bytes parsing to accept 0x prefix (e.g., 0x1234 now works, not just 1234)
- Add support for fixed-size array types in encode-calldata (e.g., uint64[3] with [1234,5678,9012])

**Documentation**
- Update README with new commands: create2-address, encode-calldata, decode-calldata, authorize
- Update README to show keccak alias for hash command

## Examples

### Better receipt print

```
$ rex receipt 0xdb71a29300fd372ced76e37260034e1e7c48334889fad676f017630e490d67df
Receipt for transaction 0xdb71a29300fd372ced76e37260034e1e7c48334889fad676f017630e490d67df:
  transaction index:    126
  from:                 0x000aebc2568796fdb763cab67b31e0fee58fe17d
  to:                   0x039efa1cb568c5daa8c41ad887d9332ce68a9a06
  gas used:             94838
  effective gas price:  1200008
  contract address:
  blob gas price:
  blob gas used:
  status:               success
  cumulative gas used:  12095726
  logs bloom:           0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000080000000000000000000000000000000000000002000000000000000000000000000000000000000000040000000020000000000000000000000000000000000000000000000000000400000000000000000000000800000000000000000000000000000000000000000800000000000000000000
  tx type:              EIP1559
  block hash:           0x922c7afbb9f4845579bce116224c3e24697137c7b256a49b899a7a637d51344a
  block number:         153
  transaction hash:     0xdb71a29300fd372ced76e37260034e1e7c48334889fad676f017630e490d67df
  logs:
    [126] address:      0x039efa1cb568c5daa8c41ad887d9332ce68a9a06
         topics:
           [0] 0x7d76dd36798b00b9c38def780dc4741f49a0f441afba4260388a8f5634eac186
           [1] 0x000000000000000000000000000aebc2568796fdb763cab67b31e0fee58fe17d
         data: 0x000000000000000000000000000000000000000000000000000000000000ffff000000000000000000000000000000000000000000000000000000000000ffff000000000000000000000000000000000000000000000000000000000000007e0000000000000000000000000000000000000000019d971e4fe8401e740000000000000000000000000000000000000000000000000000000000000000019a2800000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000024b0f4d395000000000000000000000000000aebc2568796fdb763cab67b31e0fee58fe17d00000000000000000000000000000000000000000000000000000000
```

### Better Transaction Display (`rex tx`)
```
$ rex tx 0x149eaf7a3873ff49a9e2800e261abbe44115d860e9640c2587f94b31ae8bd7ab
Transaction 0x149eaf7a3873ff49a9e2800e261abbe44115d860e9640c2587f94b31ae8bd7ab:
  type:               EIP1559
  from:               0x17d6e059e156e245871c9995b0e8add553d50d79
  to:                 0xd15fe25ed0dba12fe05e7029c88b10c25e8880e3
  value:              2225362083535689
  nonce:              3524
  gas limit:          100000
  max fee per gas:    927742796
  max priority fee:   0
  chain id:           560048
  input:              0xe63d38ed00000000000000000000000000000000...
```

### Keccak Alias
```
$ rex keccak --input 0x1234
0x56570de287d73cd1cb6092bb8fdee6173974955fdef345ae579ee9f475ea7432
```

### Bytes Parsing with 0x Prefix
```
$ rex encode-calldata "test(bytes)" 0x1234
0x2f570a2300000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002123400...
```

### Array Types Support
```
$ rex encode-calldata "test(uint64[3])" "[1234,5678,9012]"
0x479b0b4d00000000000000000000000000000000000000000000000000000000000004d2000000000000000000000000000000000000000000000000000000000000162e0000000000000000000000000000000000000000000000000000000000002334
```