### PR TITLE
chore(cli,sdk): bump cargo toml version for 8.0.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "7.0.0"
+version = "8.0.0"
 edition = "2024"
 
 [workspace.lints.rust]


### PR DESCRIPTION
**Motivation**

Bumps cargo toml version for 8.0.0 release

