### PR TITLE
feat(cli,sdk): add claim-native-withdraw command

### DIFF
--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -17,7 +17,10 @@ use rex_sdk::{
     l2::fees::fetch_fee_info,
     l2::{
         deposit::{deposit_erc20, deposit_through_contract_call},
-        withdraw::{claim_erc20withdraw, claim_withdraw, withdraw, withdraw_erc20},
+        withdraw::{
+            claim_erc20withdraw, claim_native_withdraw, claim_withdraw,
+            get_native_withdrawal_proof, withdraw, withdraw_erc20,
+        },
     },
     wait_for_transaction_receipt,
 };
@@ -112,6 +115,32 @@ pub(crate) enum Command {
         l1_rpc_url: Url,
         #[arg(long, env = "RPC_URL", default_value = "http://localhost:1729")]
         rpc_url: Url,
+    },
+    #[clap(about = "Finalize a pending native rollup withdrawal.")]
+    ClaimNativeWithdraw {
+        l2_withdrawal_tx_hash: H256,
+        #[clap(value_parser = parse_private_key, env = "PRIVATE_KEY")]
+        private_key: SecretKey,
+        #[arg(env = "NATIVE_ROLLUP_ADDRESS")]
+        native_rollup_address: Address,
+        #[arg(env = "L1_RPC_URL", default_value = "http://localhost:8545")]
+        l1_rpc_url: Url,
+        #[arg(env = "RPC_URL", default_value = "http://localhost:1729")]
+        rpc_url: Url,
+        #[clap(
+            long,
+            short = 'c',
+            required = false,
+            help = "Send the request asynchronously."
+        )]
+        cast: bool,
+        #[clap(
+            long,
+            short = 's',
+            required = false,
+            help = "Display only the tx hash."
+        )]
+        silent: bool,
     },
     #[clap(about = "Deploy a contract")]
     Deploy {
@@ -501,6 +530,43 @@ impl Command {
                 };
 
                 println!("Withdrawal claim sent: {tx_hash:#x}");
+
+                if !cast {
+                    wait_for_transaction_receipt(tx_hash, &eth_client, 100, silent).await?;
+                }
+            }
+            Command::ClaimNativeWithdraw {
+                l2_withdrawal_tx_hash,
+                private_key,
+                native_rollup_address,
+                l1_rpc_url,
+                rpc_url,
+                cast,
+                silent,
+            } => {
+                println!(
+                    "Fetching native withdrawal proof for tx {l2_withdrawal_tx_hash:#x}..."
+                );
+
+                let proof =
+                    get_native_withdrawal_proof(rpc_url.as_str(), l2_withdrawal_tx_hash).await?;
+
+                println!(
+                    "Proof received: from={:#x}, receiver={:#x}, amount={}, block={}",
+                    proof.from, proof.receiver, proof.amount, proof.block_number
+                );
+
+                let eth_client = EthClient::new(l1_rpc_url)?;
+
+                let tx_hash = claim_native_withdraw(
+                    &proof,
+                    private_key,
+                    &eth_client,
+                    native_rollup_address,
+                )
+                .await?;
+
+                println!("Native withdrawal claim sent: {tx_hash:#x}");
 
                 if !cast {
                     wait_for_transaction_receipt(tx_hash, &eth_client, 100, silent).await?;

--- a/sdk/src/l2/withdraw.rs
+++ b/sdk/src/l2/withdraw.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use ethrex_common::{Address, Bytes, U256, types::TxType};
 use ethrex_l2_common::{
     calldata::Value, messages::L1MessageProof, utils::get_address_from_secret_key,
@@ -175,5 +177,168 @@ pub async fn claim_erc20withdraw(
 
     let signer = Signer::Local(LocalSigner::new(from_pk));
 
+    send_generic_transaction(eth_client, claim_tx, &signer).await
+}
+
+// Native rollup withdrawal support
+
+fn deserialize_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    let s = s.strip_prefix("0x").unwrap_or(&s);
+    U256::from_str_radix(s, 16).map_err(serde::de::Error::custom)
+}
+
+fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    let s = s.strip_prefix("0x").unwrap_or(&s);
+    u64::from_str_radix(s, 16).map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeWithdrawalProof {
+    pub from: Address,
+    pub receiver: Address,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub amount: U256,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub message_id: U256,
+    #[serde(deserialize_with = "deserialize_u64")]
+    pub block_number: u64,
+    pub account_proof: Vec<String>,
+    pub storage_proof: Vec<String>,
+}
+
+pub async fn get_native_withdrawal_proof(
+    l2_rpc_url: &str,
+    tx_hash: H256,
+) -> Result<NativeWithdrawalProof, EthClientError> {
+    #[derive(serde::Deserialize)]
+    struct JsonRpcResponse {
+        result: Option<NativeWithdrawalProof>,
+        error: Option<JsonRpcError>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct JsonRpcError {
+        message: String,
+    }
+
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "ethrex_getNativeWithdrawalProof",
+        "params": [format!("{tx_hash:#x}")],
+        "id": 1
+    });
+
+    let max_retries: u32 = 60;
+    let mut attempts: u32 = 0;
+
+    loop {
+        let response = client
+            .post(l2_rpc_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| EthClientError::Custom(e.to_string()))?;
+
+        let rpc_response: JsonRpcResponse = response
+            .json()
+            .await
+            .map_err(|e| EthClientError::Custom(e.to_string()))?;
+
+        if let Some(error) = rpc_response.error {
+            attempts = attempts.checked_add(1).unwrap_or(u32::MAX);
+            if attempts >= max_retries {
+                return Err(EthClientError::Custom(format!(
+                    "Failed to get native withdrawal proof after {max_retries} attempts: {}",
+                    error.message
+                )));
+            }
+            println!(
+                "Waiting for native withdrawal proof (attempt {attempts}/{max_retries})..."
+            );
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            continue;
+        }
+
+        return rpc_response.result.ok_or(EthClientError::Custom(
+            "RPC response contained neither result nor error".to_owned(),
+        ));
+    }
+}
+
+pub async fn claim_native_withdraw(
+    proof: &NativeWithdrawalProof,
+    from_pk: SecretKey,
+    eth_client: &EthClient,
+    native_rollup_address: Address,
+) -> Result<H256, EthClientError> {
+    let from =
+        get_address_from_secret_key(&from_pk.secret_bytes()).map_err(EthClientError::Custom)?;
+
+    println!(
+        "Claiming native withdrawal of {} to {:#x}",
+        proof.amount, proof.receiver
+    );
+
+    const CLAIM_NATIVE_WITHDRAWAL_SIGNATURE: &str =
+        "claimWithdrawal(address,address,uint256,uint256,uint256,bytes[],bytes[])";
+
+    let account_proof: Vec<Value> = proof
+        .account_proof
+        .iter()
+        .map(|s| {
+            let hex_str = s.strip_prefix("0x").unwrap_or(s);
+            hex::decode(hex_str)
+                .map(|bytes| Value::Bytes(Bytes::from(bytes)))
+                .map_err(|e| EthClientError::Custom(e.to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let storage_proof: Vec<Value> = proof
+        .storage_proof
+        .iter()
+        .map(|s| {
+            let hex_str = s.strip_prefix("0x").unwrap_or(s);
+            hex::decode(hex_str)
+                .map(|bytes| Value::Bytes(Bytes::from(bytes)))
+                .map_err(|e| EthClientError::Custom(e.to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let calldata_values = vec![
+        Value::Address(proof.from),
+        Value::Address(proof.receiver),
+        Value::Uint(proof.amount),
+        Value::Uint(proof.message_id),
+        Value::Uint(U256::from(proof.block_number)),
+        Value::Array(account_proof),
+        Value::Array(storage_proof),
+    ];
+
+    let calldata = encode_calldata(CLAIM_NATIVE_WITHDRAWAL_SIGNATURE, &calldata_values)?;
+
+    let claim_tx = build_generic_tx(
+        eth_client,
+        TxType::EIP1559,
+        native_rollup_address,
+        from,
+        calldata.into(),
+        Overrides {
+            from: Some(from),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let signer = Signer::Local(LocalSigner::new(from_pk));
     send_generic_transaction(eth_client, claim_tx, &signer).await
 }


### PR DESCRIPTION
**Motivation**

ethrex PR #6248 adds a "native rollup" mode where L2→L1 withdrawals use MPT state proofs instead of batch/merkle proofs. Rex needs a command to finalize these native rollup withdrawals by fetching the proof from L2 and submitting the claim transaction on L1.

**Description**

Adds `rex l2 claim-native-withdraw` command that:

1. Fetches the MPT proof from L2 via `ethrex_getNativeWithdrawalProof` RPC (with retry logic, up to 60 attempts)
2. Calls `claimWithdrawal(address,address,uint256,uint256,uint256,bytes[],bytes[])` on the L1 NativeRollup contract

**Usage:**
```
rex l2 claim-native-withdraw <L2_TX_HASH> <PRIVATE_KEY> <NATIVE_ROLLUP_ADDRESS> [L1_RPC_URL] [RPC_URL]
```

**Changes:**
- `sdk/src/l2/withdraw.rs` — `NativeWithdrawalProof` struct, `get_native_withdrawal_proof()`, `claim_native_withdraw()`
- `cli/src/commands/l2.rs` — `ClaimNativeWithdraw` command variant and handler