### PR TITLE
ci(ci): add explicit least-privilege permissions to workflow files

### DIFF
--- a/.github/workflows/pr_lint_gha.yml
+++ b/.github/workflows/pr_lint_gha.yml
@@ -6,6 +6,9 @@ on:
       - ".github/**.yaml"
       - ".github/*.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pr_lint_pr_title.yml
+++ b/.github/workflows/pr_lint_pr_title.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - edited
 
+permissions:
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pr_main_cli.yml
+++ b/.github/workflows/pr_main_cli.yml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - "sdk/**" # We run this in a separate workflow
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pr_main_sdk.yml
+++ b/.github/workflows/pr_main_sdk.yml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - "cli/**" # We run this in a separate workflow
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds explicit `permissions:` blocks to all workflow files to restrict `GITHUB_TOKEN` to least-privilege
- `pr_lint_pr_title.yml` → `pull-requests: read` (only reads PR metadata, no checkout)
- `pr_lint_gha.yml` → `contents: read` (checkout + actionlint)
- `pr_main_cli.yml` → `contents: read` (checkout + cargo build/test/lint)
- `pr_main_sdk.yml` → `contents: read` (checkout + cargo build/test/lint)

## Related code scanning alerts

- `pr_lint_pr_title.yml` — [#1](https://github.com/lambdaclass/rex/security/code-scanning/1)
- `pr_lint_gha.yml` — [#2](https://github.com/lambdaclass/rex/security/code-scanning/2)
- `pr_main_cli.yml` — [#3](https://github.com/lambdaclass/rex/security/code-scanning/3), [#16](https://github.com/lambdaclass/rex/security/code-scanning/16)
- `pr_main_sdk.yml` — [#4](https://github.com/lambdaclass/rex/security/code-scanning/4), [#15](https://github.com/lambdaclass/rex/security/code-scanning/15)