### PR TITLE
fix(ci): fix actionlint path filter and lint errors

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -4,7 +4,6 @@ inputs:
   components:
     description: "Rust components to install (e.g., rustfmt, clippy)"
     required: false
-    type: string
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/daily_reports.yml
+++ b/.github/workflows/daily_reports.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Wait for ethrex l2
         run: |
-          for i in {1..100}; do
+          for _ in {1..100}; do
             if nc -z localhost 3900; then
               echo "ProofCoordinator ready!"
               exit 0
@@ -90,7 +90,7 @@ jobs:
 
       - name: Wait for ethrex l2
         run: |
-          for i in {1..100}; do
+          for _ in {1..100}; do
             if nc -z localhost 3900; then
               echo "ProofCoordinator ready!"
               exit 0

--- a/.github/workflows/pr_lint_gha.yml
+++ b/.github/workflows/pr_lint_gha.yml
@@ -4,7 +4,7 @@ on:
     branches: ["**"]
     paths:
       - ".github/**.yaml"
-      - ".github/*.yml"
+      - ".github/**.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Wait for ethrex l2
         run: |
-          for i in {1..100}; do
+          for _ in {1..100}; do
             if nc -z localhost 3900; then
               echo "ProofCoordinator ready!"
               exit 0
@@ -95,7 +95,7 @@ jobs:
 
       - name: Wait for ethrex l2
         run: |
-          for i in {1..100}; do
+          for _ in {1..100}; do
             if nc -z localhost 3900; then
               echo "Service ready!"
               exit 0


### PR DESCRIPTION
## Summary
- Fix the path filter glob in `pr_lint_gha.yml` to match workflow files in subdirectories (`.github/*.yml` → `.github/**.yml`)
- Fix 4 unused loop variable warnings in `daily_reports.yml` and `pr_main.yml` (`for i in` → `for _ in`)
- Remove invalid `type: string` key from `setup-rust` composite action inputs

## Test plan
- [ ] "Github Actions" lint job triggers on this PR and passes