### PR TITLE
feat(cli): add rex wallet derive BIP-39 mnemonic → account derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -361,6 +361,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -370,6 +376,12 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bincode"
@@ -474,6 +486,16 @@ dependencies = [
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
 ]
 
 [[package]]
@@ -647,6 +669,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "const-hex",
+ "digest",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2",
+ "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +764,18 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -1221,7 +1306,7 @@ dependencies = [
  "digest",
  "hex",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "rand 0.8.5",
  "scrypt",
  "serde",
@@ -1979,7 +2064,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -2145,7 +2230,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2444,7 +2529,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -3073,12 +3158,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3245,6 +3340,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,7 +3599,7 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3520,6 +3639,8 @@ version = "8.0.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "coins-bip32",
+ "coins-bip39",
  "colored 3.0.0",
  "dialoguer",
  "dirs",
@@ -3808,7 +3929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "salsa20",
  "sha2",
 ]
@@ -3960,7 +4081,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4758,6 +4879,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,6 +29,8 @@ strum = "0.27.1"
 # Crypto
 keccak-hash.workspace = true
 secp256k1.workspace = true
+coins-bip32 = "0.12"
+coins-bip39 = "0.12"
 
 # Utils
 hex.workspace = true

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::commands::l2;
+use crate::commands::{l2, wallet};
 use crate::common::AuthorizeArgs;
 use crate::utils::{parse_contract_creation, parse_func_call, parse_hex, parse_hex_string};
 use crate::{
@@ -290,6 +290,8 @@ pub(crate) enum Command {
         #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
     },
+    #[clap(subcommand, about = "Wallet utilities (mnemonic derivation, etc).")]
+    Wallet(wallet::Command),
 }
 
 impl Command {
@@ -297,6 +299,7 @@ impl Command {
         match self {
             Command::L2(cmd) => cmd.run().await?,
             Command::Autocomplete(cmd) => cmd.run()?,
+            Command::Wallet(cmd) => cmd.run()?,
             Command::Balance {
                 account,
                 token_address,

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod autocomplete;
 pub(crate) mod l2;
+pub(crate) mod wallet;

--- a/cli/src/commands/wallet.rs
+++ b/cli/src/commands/wallet.rs
@@ -73,8 +73,9 @@ impl Command {
                 output,
                 force,
             } => {
-                let mnemonic: Mnemonic<English> = Mnemonic::<English>::new_from_phrase(&mnemonic)
-                    .map_err(|e| eyre::eyre!("invalid mnemonic: {e}"))?;
+                let mnemonic: Mnemonic<English> =
+                    Mnemonic::<English>::new_from_phrase(&mnemonic)
+                        .map_err(|e| eyre::eyre!("invalid mnemonic: {e}"))?;
 
                 let mut keys: Vec<DerivedKey> = Vec::new();
                 for i in index {

--- a/cli/src/commands/wallet.rs
+++ b/cli/src/commands/wallet.rs
@@ -6,23 +6,27 @@ use ethrex_common::{Address, H256};
 use ethrex_l2_common::utils::get_address_from_secret_key;
 use rex_sdk::utils::to_checksum_address;
 use secp256k1::SecretKey;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::ops::RangeInclusive;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
     #[clap(
-        about = "Derive Ethereum accounts from a BIP-39 mnemonic",
+        about = "Derive Ethereum accounts from a BIP-39 mnemonic (writes keys to a file)",
         long_about = "Derive Ethereum accounts from a BIP-39 mnemonic using the standard \
-                      m/44'/60'/0'/0/{index} path. Useful for recovering keys from Kurtosis \
-                      pre-funded accounts, Anvil/Hardhat test mnemonics, or hardware wallets \
-                      seeded with a known phrase."
+                      m/44'/60'/0'/0/{index} path. Keys are written to the file given by \
+                      --output (never stdout) with mode 0600 on Unix. stdout only shows the \
+                      derived addresses and the output path, so pasting a terminal log never \
+                      leaks secrets. Read the file back with `cat` when you need the keys."
     )]
     Derive {
         #[arg(
             long,
             env = "MNEMONIC",
-            help = "BIP-39 mnemonic phrase (12 or 24 words, space-separated). Can also be passed via the MNEMONIC env var."
+            help = "BIP-39 mnemonic phrase (12 or 24 words, space-separated). Also read from the MNEMONIC env var."
         )]
         mnemonic: String,
         #[arg(
@@ -39,12 +43,24 @@ pub(crate) enum Command {
         )]
         passphrase: String,
         #[arg(
+            short = 'o',
+            long = "output",
+            help = "Path to write derived keys to. Created with mode 0600 on Unix. Use --force to overwrite an existing file."
+        )]
+        output: PathBuf,
+        #[arg(
             long,
             default_value_t = false,
-            help = "Print only comma-separated address,private_key pairs, one per line (machine-friendly)."
+            help = "Overwrite the output file if it already exists."
         )]
-        csv: bool,
+        force: bool,
     },
+}
+
+struct DerivedKey {
+    index: u32,
+    address: Address,
+    private_key: H256,
 }
 
 impl Command {
@@ -54,12 +70,13 @@ impl Command {
                 mnemonic,
                 index,
                 passphrase,
-                csv,
+                output,
+                force,
             } => {
-                let mnemonic: Mnemonic<English> =
-                    Mnemonic::<English>::new_from_phrase(&mnemonic)
-                        .map_err(|e| eyre::eyre!("invalid mnemonic: {e}"))?;
+                let mnemonic: Mnemonic<English> = Mnemonic::<English>::new_from_phrase(&mnemonic)
+                    .map_err(|e| eyre::eyre!("invalid mnemonic: {e}"))?;
 
+                let mut keys: Vec<DerivedKey> = Vec::new();
                 for i in index {
                     let path = DerivationPath::from_str(&format!("m/44'/60'/0'/0/{i}"))
                         .map_err(|e| eyre::eyre!("invalid derivation path: {e}"))?;
@@ -70,30 +87,83 @@ impl Command {
                     let secret_bytes: [u8; 32] = signing_key.to_bytes().into();
                     let secret = SecretKey::from_slice(&secret_bytes)
                         .map_err(|e| eyre::eyre!("secp256k1 error at index {i}: {e}"))?;
-                    let address: Address = get_address_from_secret_key(&secret.secret_bytes())
+                    let address = get_address_from_secret_key(&secret.secret_bytes())
                         .map_err(|e| eyre::eyre!(e))?;
-                    let pk = H256::from(secret_bytes);
+                    keys.push(DerivedKey {
+                        index: i,
+                        address,
+                        private_key: H256::from(secret_bytes),
+                    });
+                }
 
-                    if csv {
-                        println!(
-                            "0x{},{:x}",
-                            to_checksum_address(&format!("{address:x}")),
-                            pk
-                        );
-                    } else {
-                        println!("Index:       {i}");
-                        println!(
-                            "Address:     0x{}",
-                            to_checksum_address(&format!("{address:x}"))
-                        );
-                        println!("Private Key: {pk:x}");
-                        println!();
-                    }
+                write_keys_file(&output, &keys, force)?;
+
+                println!("Wrote {} key(s) to {}", keys.len(), output.display());
+                for k in &keys {
+                    println!(
+                        "  index {:>3}  0x{}",
+                        k.index,
+                        to_checksum_address(&format!("{:x}", k.address))
+                    );
                 }
                 Ok(())
             }
         }
     }
+}
+
+fn write_keys_file(path: &std::path::Path, keys: &[DerivedKey], force: bool) -> eyre::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    if force {
+        opts.create(true).truncate(true);
+    } else {
+        opts.create_new(true);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+
+    let mut file = opts.open(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            eyre::eyre!(
+                "{} already exists; pass --force to overwrite",
+                path.display()
+            )
+        } else {
+            eyre::eyre!("failed to open {}: {e}", path.display())
+        }
+    })?;
+
+    // Belt-and-braces: also set mode after open in case the file existed
+    // under --force (OpenOptions::mode only applies on creation).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = file.metadata()?.permissions();
+        perm.set_mode(0o600);
+        file.set_permissions(perm)?;
+    }
+
+    writeln!(
+        file,
+        "# rex wallet derive — {} key(s), m/44'/60'/0'/0/{{index}}",
+        keys.len()
+    )?;
+    for k in keys {
+        writeln!(file)?;
+        writeln!(file, "Index:       {}", k.index)?;
+        writeln!(
+            file,
+            "Address:     0x{}",
+            to_checksum_address(&format!("{:x}", k.address))
+        )?;
+        writeln!(file, "Private Key: {:x}", k.private_key)?;
+    }
+    file.sync_all()?;
+    Ok(())
 }
 
 fn parse_index_range(s: &str) -> eyre::Result<RangeInclusive<u32>> {
@@ -145,5 +215,39 @@ mod tests {
         assert_eq!(parse_index_range("2-5").unwrap(), 2..=5);
         assert!(parse_index_range("5-2").is_err());
         assert!(parse_index_range("abc").is_err());
+    }
+
+    #[test]
+    fn write_keys_file_creates_file_with_expected_content() {
+        let tmp = std::env::temp_dir().join(format!("rex-wallet-test-{}.txt", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+
+        let keys = vec![DerivedKey {
+            index: 0,
+            address: Address::from_low_u64_be(0xc0ffee),
+            private_key: H256::from_low_u64_be(0x1234),
+        }];
+        write_keys_file(&tmp, &keys, false).unwrap();
+
+        let contents = std::fs::read_to_string(&tmp).unwrap();
+        assert!(contents.contains("Index:       0"));
+        assert!(contents.contains("Private Key:"));
+        assert!(contents.contains("0x"));
+
+        // Second write without --force should fail.
+        let err = write_keys_file(&tmp, &keys, false).unwrap_err();
+        assert!(format!("{err}").contains("already exists"));
+
+        // With --force it should overwrite.
+        write_keys_file(&tmp, &keys, true).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&tmp).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "file must be 0600");
+        }
+
+        std::fs::remove_file(&tmp).ok();
     }
 }

--- a/cli/src/commands/wallet.rs
+++ b/cli/src/commands/wallet.rs
@@ -1,0 +1,149 @@
+use clap::Subcommand;
+use coins_bip32::ecdsa::SigningKey;
+use coins_bip32::path::DerivationPath;
+use coins_bip39::{English, Mnemonic};
+use ethrex_common::{Address, H256};
+use ethrex_l2_common::utils::get_address_from_secret_key;
+use rex_sdk::utils::to_checksum_address;
+use secp256k1::SecretKey;
+use std::ops::RangeInclusive;
+use std::str::FromStr;
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    #[clap(
+        about = "Derive Ethereum accounts from a BIP-39 mnemonic",
+        long_about = "Derive Ethereum accounts from a BIP-39 mnemonic using the standard \
+                      m/44'/60'/0'/0/{index} path. Useful for recovering keys from Kurtosis \
+                      pre-funded accounts, Anvil/Hardhat test mnemonics, or hardware wallets \
+                      seeded with a known phrase."
+    )]
+    Derive {
+        #[arg(
+            long,
+            env = "MNEMONIC",
+            help = "BIP-39 mnemonic phrase (12 or 24 words, space-separated). Can also be passed via the MNEMONIC env var."
+        )]
+        mnemonic: String,
+        #[arg(
+            long,
+            default_value = "0",
+            value_parser = parse_index_range,
+            help = "Account index or inclusive range, e.g. '0', '0-4'."
+        )]
+        index: RangeInclusive<u32>,
+        #[arg(
+            long,
+            default_value = "",
+            help = "Optional BIP-39 passphrase (empty by default)."
+        )]
+        passphrase: String,
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Print only comma-separated address,private_key pairs, one per line (machine-friendly)."
+        )]
+        csv: bool,
+    },
+}
+
+impl Command {
+    pub fn run(self) -> eyre::Result<()> {
+        match self {
+            Command::Derive {
+                mnemonic,
+                index,
+                passphrase,
+                csv,
+            } => {
+                let mnemonic: Mnemonic<English> =
+                    Mnemonic::<English>::new_from_phrase(&mnemonic)
+                        .map_err(|e| eyre::eyre!("invalid mnemonic: {e}"))?;
+
+                for i in index {
+                    let path = DerivationPath::from_str(&format!("m/44'/60'/0'/0/{i}"))
+                        .map_err(|e| eyre::eyre!("invalid derivation path: {e}"))?;
+                    let xpriv = mnemonic
+                        .derive_key(&path, Some(&passphrase))
+                        .map_err(|e| eyre::eyre!("key derivation failed at index {i}: {e}"))?;
+                    let signing_key: &SigningKey = xpriv.as_ref();
+                    let secret_bytes: [u8; 32] = signing_key.to_bytes().into();
+                    let secret = SecretKey::from_slice(&secret_bytes)
+                        .map_err(|e| eyre::eyre!("secp256k1 error at index {i}: {e}"))?;
+                    let address: Address = get_address_from_secret_key(&secret.secret_bytes())
+                        .map_err(|e| eyre::eyre!(e))?;
+                    let pk = H256::from(secret_bytes);
+
+                    if csv {
+                        println!(
+                            "0x{},{:x}",
+                            to_checksum_address(&format!("{address:x}")),
+                            pk
+                        );
+                    } else {
+                        println!("Index:       {i}");
+                        println!(
+                            "Address:     0x{}",
+                            to_checksum_address(&format!("{address:x}"))
+                        );
+                        println!("Private Key: {pk:x}");
+                        println!();
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn parse_index_range(s: &str) -> eyre::Result<RangeInclusive<u32>> {
+    if let Some((lo, hi)) = s.split_once('-') {
+        let lo: u32 = lo
+            .parse()
+            .map_err(|e| eyre::eyre!("invalid range start '{lo}': {e}"))?;
+        let hi: u32 = hi
+            .parse()
+            .map_err(|e| eyre::eyre!("invalid range end '{hi}': {e}"))?;
+        if hi < lo {
+            return Err(eyre::eyre!("range end {hi} is less than start {lo}"));
+        }
+        Ok(lo..=hi)
+    } else {
+        let idx: u32 = s
+            .parse()
+            .map_err(|e| eyre::eyre!("invalid index '{s}': {e}"))?;
+        Ok(idx..=idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Standard test mnemonic used by Anvil/Hardhat. Derives a well-known set
+    // of addresses — if this test starts failing, the derivation path is wrong.
+    const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
+
+    #[test]
+    fn derives_anvil_account_zero() {
+        let mnemonic = Mnemonic::<English>::new_from_phrase(TEST_MNEMONIC).unwrap();
+        let path = DerivationPath::from_str("m/44'/60'/0'/0/0").unwrap();
+        let key = mnemonic.derive_key(&path, Some("")).unwrap();
+        let signing_key: &SigningKey = key.as_ref();
+        let secret_bytes: [u8; 32] = signing_key.to_bytes().into();
+        let secret = SecretKey::from_slice(&secret_bytes).unwrap();
+        let addr = get_address_from_secret_key(&secret.secret_bytes()).unwrap();
+        assert_eq!(
+            format!("0x{addr:x}"),
+            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+        );
+    }
+
+    #[test]
+    fn parses_index_range() {
+        assert_eq!(parse_index_range("0").unwrap(), 0..=0);
+        assert_eq!(parse_index_range("2-5").unwrap(), 2..=5);
+        assert!(parse_index_range("5-2").is_err());
+        assert!(parse_index_range("abc").is_err());
+    }
+}


### PR DESCRIPTION
`rex wallet derive --mnemonic "..." --index 0` derives an Ethereum account from a mnemonic along the standard `m/44'/60'/0'/0/{index}` path. Supports inclusive ranges like `--index 0-4`, optional BIP-39 passphrase, MNEMONIC env var. Outputs to a file. 

Output format matches the improvement doc: Address and Private Key lines. Verified against the Anvil/Hardhat test mnemonic; account `0` produces `0xf39F…2266` as expected.