### PR TITLE
feat(cli,sdk): support eth_call state overrides

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,32 +1,35 @@
 # CLI
 
-- [How to install](#how-to-install)
-- [How to run](#how-to-run)
-- [Commands](#commands)
-  - [`rex address`](#rex-address)
-  - [`rex autocomplete`](#rex-autocomplete)
-  - [`rex balance`](#rex-balance)
-  - [`rex block-number`](#rex-block-number)
-  - [`rex call`](#rex-call)
-  - [`rex chain-id`](#rex-chain-id)
-  - [`rex code`](#rex-code)
-  - [`rex create-address`](#rex-create-address)
-  - [`rex create2-address`](#rex-create2-address)
-  - [`rex decode-calldata`](#rex-decode-calldata)
-  - [`rex deploy`](#rex-deploy)
-  - [`rex encode-calldata`](#rex-encode-calldata)
-  - [`rex hash`](#rex-hash)
-  - [`rex help`](#rex-help)
-  - [`rex l2`](#rex-l2)
-  - [`rex nonce`](#rex-nonce)
-  - [`rex receipt`](#rex-receipt)
-  - [`rex send`](#rex-send)
-  - [`rex sign`](#rex-sign)
-  - [`rex signer`](#rex-signer)
-  - [`rex transaction`](#rex-transaction)
-  - [`rex transfer`](#rex-transfer)
-  - [`rex verify-signature`](#rex-verify-signature)
-- [Examples](#examples)
+- [CLI](#cli)
+  - [How to install](#how-to-install)
+  - [How to run](#how-to-run)
+  - [Commands](#commands)
+    - [`rex address`](#rex-address)
+    - [`rex autocomplete`](#rex-autocomplete)
+    - [`rex balance`](#rex-balance)
+    - [`rex block-number`](#rex-block-number)
+    - [`rex call`](#rex-call)
+      - [State overrides](#state-overrides)
+        - [Stacking multiple overrides](#stacking-multiple-overrides)
+    - [`rex chain-id`](#rex-chain-id)
+    - [`rex code`](#rex-code)
+    - [`rex create-address`](#rex-create-address)
+    - [`rex create2-address`](#rex-create2-address)
+    - [`rex decode-calldata`](#rex-decode-calldata)
+    - [`rex deploy`](#rex-deploy)
+    - [`rex encode-calldata`](#rex-encode-calldata)
+    - [`rex hash`](#rex-hash)
+    - [`rex help`](#rex-help)
+    - [`rex l2`](#rex-l2)
+    - [`rex nonce`](#rex-nonce)
+    - [`rex receipt`](#rex-receipt)
+    - [`rex send`](#rex-send)
+    - [`rex sign`](#rex-sign)
+    - [`rex signer`](#rex-signer)
+    - [`rex transaction`](#rex-transaction)
+    - [`rex transfer`](#rex-transfer)
+    - [`rex verify-signature`](#rex-verify-signature)
+  - [Examples](#examples)
 
 
 ## How to install
@@ -119,11 +122,19 @@ Arguments:
   <ACCOUNT>
 
 Options:
-      --token <TOKEN_ADDRESS>  Specify the token address, the ETH is used as default.
-      --eth                    Display the balance in ETH.
-      --rpc-url <RPC_URL>      [env: RPC_URL=] [default: http://localhost:8545]
-  -h, --help                   Print help
+      --token <TOKEN_ADDRESS>                       Specify the token address, the ETH is used as default.
+      --eth                                         Display the balance in ETH.
+      --rpc-url <RPC_URL>                           [env: RPC_URL=] [default: http://localhost:8545]
+      --override-balance <ADDR:VALUE>               Override an account's balance for this call (see [State overrides](#state-overrides)).
+      --override-nonce <ADDR:VALUE>                 Override an account's nonce for this call.
+      --override-code <ADDR:HEX>                    Override an account's bytecode for this call.
+      --override-state <ADDR:SLOT:VALUE>            Replace a storage slot for this call.
+      --override-state-diff <ADDR:SLOT:VALUE>       Overlay a storage slot for this call.
+      --override-move-precompile <ADDR:TARGET>      Relocate a precompile to a different address.
+  -h, --help                                        Print help
 ```
+
+State overrides require the token form (`--token`); plain ETH balance reads use `eth_getBalance`, which does not accept overrides.
 
 ### `rex block-number`
 
@@ -149,14 +160,79 @@ Arguments:
   [ARGS]...
 
 Options:
-      --calldata <CALLDATA>                [default: ]
-      --value <VALUE>                      Value to send in wei [default: 0]
+      --calldata <CALLDATA>                         [default: ]
+      --value <VALUE>                               Value to send in wei [default: 0]
       --from <FROM>
       --gas-limit <GAS_LIMIT>
       --max-fee-per-gas <MAX_FEE_PER_GAS>
-      --explorer-url                       Display transaction URL in the explorer.
-      --rpc-url <RPC_URL>                  [env: RPC_URL=] [default: http://localhost:8545]
-  -h, --help                               Print help
+      --explorer-url                                Display transaction URL in the explorer.
+      --rpc-url <RPC_URL>                           [env: RPC_URL=] [default: http://localhost:8545]
+      --override-balance <ADDR:VALUE>               Override an account's balance for this call (see [State overrides](#state-overrides)).
+      --override-nonce <ADDR:VALUE>                 Override an account's nonce for this call.
+      --override-code <ADDR:HEX>                    Override an account's bytecode for this call.
+      --override-state <ADDR:SLOT:VALUE>            Replace a storage slot for this call.
+      --override-state-diff <ADDR:SLOT:VALUE>       Overlay a storage slot for this call.
+      --override-move-precompile <ADDR:TARGET>      Relocate a precompile to a different address.
+  -h, --help                                        Print help
+```
+
+#### State overrides
+
+`rex call` and `rex balance --token …` accept a State Override Set as the 3rd `eth_call` parameter, matching the format documented at <https://geth.ethereum.org/docs/interacting-with-geth/rpc/objects#state-override-set> (also implemented in ethrex as of
+[lambdaclass/ethrex#6660](https://github.com/lambdaclass/ethrex/pull/6660)).
+
+The node must support that parameter; if no override flags are passed, the 2-parameter form is used so older nodes keep working.
+
+Each flag is repeatable and scoped per address:
+
+| Flag | Format | Meaning |
+|---|---|---|
+| `--override-balance` | `ADDR:VALUE` | Set the account balance (hex `0x…` or decimal). |
+| `--override-nonce` | `ADDR:VALUE` | Set the account nonce. |
+| `--override-code` | `ADDR:HEX` | Replace the account's bytecode. |
+| `--override-state` | `ADDR:SLOT:VALUE` | Replace a storage slot, dropping every other slot for that account. |
+| `--override-state-diff` | `ADDR:SLOT:VALUE` | Overlay a single storage slot, leaving the rest unchanged. |
+| `--override-move-precompile` | `ADDR:TARGET` | Move the precompile at `ADDR` to `TARGET`. |
+
+`--override-state` and `--override-state-diff` are mutually exclusive **for the
+same address** — supplying both for one account is rejected by the node.
+
+##### Stacking multiple overrides
+
+Every flag in the table above can be passed multiple times in a single invocation, and different flag types can be mixed freely. All entries are merged into one State Override Set sent as the 3rd `eth_call` parameter:
+
+- Multiple addresses: repeat the same flag with different `ADDR` values
+  (`--override-balance 0xAAA…:0x1 --override-balance 0xBBB…:0x2`).
+- Multiple fields on one address: stack different flags sharing an `ADDR`
+  (`--override-balance 0xAAA…:0x1 --override-nonce 0xAAA…:0x7 --override-code 0xAAA…:0x…`).
+- Multiple storage slots on one address: repeat `--override-state-diff` (or
+  `--override-state`) with the same `ADDR` and different `SLOT:VALUE` pairs.
+  Don't mix `--override-state` with `--override-state-diff` for the same
+  address — the node rejects that combination.
+
+Examples:
+
+```bash
+# Pin the USDC balance of an address to 0xdeadbeef by overriding the contract's bytecode
+rex balance --token 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
+            0x37305b1cd40574e4c5ce33f8e8306be057fd7341 \
+            --override-code 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48:0x63deadbeef60005260206000f3
+
+# Or override the storage slot for that account's balance entry directly
+# (slot = keccak256(abi.encode(addr, uint256(9))) — slot 9 holds USDC's balances mapping)
+rex balance --token 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
+            0x37305b1cd40574e4c5ce33f8e8306be057fd7341 \
+            --override-state-diff 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48:0x9254cb65314db3d2d7ca17f753f1d9c7f1b6fa05111d18d10ed5b9519d1b247c:0x0123456789
+
+# Stack overrides across addresses:
+# - override USDC's balance slot for the target account
+# - fabricate a balance + nonce on an unrelated address
+rex call 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
+         --calldata 0x70a0823100000000000000000000000037305b1cd40574e4c5ce33f8e8306be057fd7341 \
+         --rpc-url http://my-node:8545 \
+         --override-state-diff 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48:0x9254cb65314db3d2d7ca17f753f1d9c7f1b6fa05111d18d10ed5b9519d1b247c:0x42 \
+         --override-balance 0x0000000000000000000000000000000000000bad:0x100 \
+         --override-nonce   0x0000000000000000000000000000000000000bad:0x7
 ```
 
 ### `rex chain-id`

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::commands::{frame, l2, wallet};
-use crate::common::AuthorizeArgs;
+use crate::common::{AuthorizeArgs, StateOverrideArgs};
 use crate::utils::{
     encode_constructor_args, parse_contract_creation, parse_func_call, parse_hex, parse_hex_string,
 };
@@ -26,7 +26,9 @@ use ethrex_sdk::{build_generic_tx, create2_deploy_from_bytecode, send_generic_tr
 use ethrex_sdk::{compile_contract, git_clone};
 use keccak_hash::keccak;
 use rex_sdk::authorize::build_authorization_tuple;
-use rex_sdk::client::eth::get_token_balance;
+use rex_sdk::client::eth::{
+    call_with_state_overrides, get_token_balance, get_token_balance_with_state_overrides,
+};
 use rex_sdk::create::{
     DETERMINISTIC_DEPLOYER, brute_force_create2, compute_create_address, compute_create2_address,
 };
@@ -89,6 +91,8 @@ pub(crate) enum Command {
         eth: bool,
         #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
+        #[clap(flatten)]
+        state_overrides: StateOverrideArgs,
     },
     #[clap(about = "Get the current block_number.", visible_alias = "bl")]
     BlockNumber {
@@ -313,11 +317,28 @@ impl Command {
                 token_address,
                 eth,
                 rpc_url,
+                state_overrides,
             } => {
                 let eth_client = EthClient::new(rpc_url)?;
                 let account_balance = if let Some(token_address) = token_address {
-                    get_token_balance(&eth_client, account, token_address).await?
+                    if state_overrides.is_empty() {
+                        get_token_balance(&eth_client, account, token_address).await?
+                    } else {
+                        let overrides = state_overrides.build()?;
+                        get_token_balance_with_state_overrides(
+                            &eth_client,
+                            account,
+                            token_address,
+                            &overrides,
+                        )
+                        .await?
+                    }
                 } else {
+                    if !state_overrides.is_empty() {
+                        return Err(eyre::eyre!(
+                            "state overrides apply to contract calls (eth_call); use --token to query an ERC-20 balance with overrides, since eth_getBalance does not accept overrides"
+                        ));
+                    }
                     eth_client
                         .get_balance(account, BlockIdentifier::Tag(BlockTag::Latest))
                         .await?
@@ -597,19 +618,27 @@ impl Command {
                     parse_func_call(args._args)?
                 };
 
-                let result = client
-                    .call(
+                let call_overrides = Overrides {
+                    from: args.from,
+                    value: args.value.into(),
+                    gas_limit: args.gas_limit,
+                    max_fee_per_gas: args.max_fee_per_gas,
+                    ..Default::default()
+                };
+
+                let result = if args.state_overrides.is_empty() {
+                    client.call(args.to, calldata, call_overrides).await?
+                } else {
+                    let state_overrides = args.state_overrides.build()?;
+                    call_with_state_overrides(
+                        &client,
                         args.to,
                         calldata,
-                        Overrides {
-                            from: args.from,
-                            value: args.value.into(),
-                            gas_limit: args.gas_limit,
-                            max_fee_per_gas: args.max_fee_per_gas,
-                            ..Default::default()
-                        },
+                        call_overrides,
+                        &state_overrides,
                     )
-                    .await?;
+                    .await?
+                };
 
                 println!("{result}");
             }

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -574,6 +574,7 @@ impl Command {
                         token_address: args.token_address,
                         eth: args.eth,
                         rpc_url,
+                        state_overrides: Default::default(),
                     }
                     .run()
                     .await

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -226,8 +226,7 @@ impl StateOverrideArgs {
             set.entry(addr).state.insert(slot, value);
         }
         for raw in &self.state_diff {
-            let (addr, slot, value) =
-                split_three(raw, "override-state-diff", "ADDR:SLOT:VALUE")?;
+            let (addr, slot, value) = split_three(raw, "override-state-diff", "ADDR:SLOT:VALUE")?;
             set.entry(addr).state_diff.insert(slot, value);
         }
         for raw in &self.move_precompile {
@@ -239,22 +238,14 @@ impl StateOverrideArgs {
     }
 }
 
-fn split_two<'a>(
-    raw: &'a str,
-    flag: &str,
-    shape: &str,
-) -> eyre::Result<(Address, &'a str)> {
+fn split_two<'a>(raw: &'a str, flag: &str, shape: &str) -> eyre::Result<(Address, &'a str)> {
     let (addr, rest) = raw
         .split_once(':')
         .ok_or_else(|| eyre::eyre!("--{flag} expects '{shape}', got '{raw}'"))?;
     Ok((Address::from_str(addr.trim())?, rest.trim()))
 }
 
-fn split_three(
-    raw: &str,
-    flag: &str,
-    shape: &str,
-) -> eyre::Result<(Address, H256, U256)> {
+fn split_three(raw: &str, flag: &str, shape: &str) -> eyre::Result<(Address, H256, U256)> {
     let mut parts = raw.splitn(3, ':');
     let addr = parts
         .next()

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use crate::utils::{parse_hex, parse_private_key, parse_u256};
 use clap::Parser;
-use ethrex_common::{Address, Bytes, Secret, U256};
+use ethrex_common::{Address, Bytes, H256, Secret, U256};
+use rex_sdk::client::eth::StateOverrideSet;
 use secp256k1::SecretKey;
 
 #[derive(Parser)]
@@ -142,8 +144,151 @@ pub struct CallArgs {
         help = "Display transaction URL in the explorer."
     )]
     pub explorer_url: bool,
+    #[clap(flatten)]
+    pub state_overrides: StateOverrideArgs,
     #[clap(required = false)]
     pub _args: Vec<String>,
+}
+
+/// State Override Set (geth-style, ethrex PR #6660). Repeatable flags scoped per
+/// address. Empty by default; when no flags are passed, `eth_call` falls back
+/// to the standard 2-parameter form.
+#[derive(Parser, Default, Clone, Debug)]
+pub struct StateOverrideArgs {
+    #[clap(
+        long = "override-balance",
+        value_name = "ADDR:VALUE",
+        help = "Override an account's balance. Format: 0xaddr:0xhex_or_dec",
+        long_help = "Set the balance of ADDR for the duration of this eth_call. \
+                     Value may be hex (0x…) or decimal. Repeat for multiple addresses."
+    )]
+    pub balance: Vec<String>,
+    #[clap(
+        long = "override-nonce",
+        value_name = "ADDR:VALUE",
+        help = "Override an account's nonce. Format: 0xaddr:NONCE"
+    )]
+    pub nonce: Vec<String>,
+    #[clap(
+        long = "override-code",
+        value_name = "ADDR:HEX",
+        help = "Override an account's bytecode. Format: 0xaddr:0xbytecode"
+    )]
+    pub code: Vec<String>,
+    #[clap(
+        long = "override-state",
+        value_name = "ADDR:SLOT:VALUE",
+        help = "Replace an account's storage slot (mutually exclusive with --override-state-diff for the same address)."
+    )]
+    pub state: Vec<String>,
+    #[clap(
+        long = "override-state-diff",
+        value_name = "ADDR:SLOT:VALUE",
+        help = "Overlay a single storage slot for an account (mutually exclusive with --override-state for the same address)."
+    )]
+    pub state_diff: Vec<String>,
+    #[clap(
+        long = "override-move-precompile",
+        value_name = "ADDR:TARGET",
+        help = "Relocate the precompile at ADDR to TARGET."
+    )]
+    pub move_precompile: Vec<String>,
+}
+
+impl StateOverrideArgs {
+    pub fn is_empty(&self) -> bool {
+        self.balance.is_empty()
+            && self.nonce.is_empty()
+            && self.code.is_empty()
+            && self.state.is_empty()
+            && self.state_diff.is_empty()
+            && self.move_precompile.is_empty()
+    }
+
+    pub fn build(&self) -> eyre::Result<StateOverrideSet> {
+        let mut set = StateOverrideSet::new();
+
+        for raw in &self.balance {
+            let (addr, value) = split_two(raw, "override-balance", "ADDR:VALUE")?;
+            set.entry(addr).balance = Some(parse_u256(value)?);
+        }
+        for raw in &self.nonce {
+            let (addr, value) = split_two(raw, "override-nonce", "ADDR:VALUE")?;
+            set.entry(addr).nonce = Some(parse_u64_flex(value)?);
+        }
+        for raw in &self.code {
+            let (addr, value) = split_two(raw, "override-code", "ADDR:HEX")?;
+            let bytes = parse_hex(value).map_err(|e| eyre::eyre!("invalid code hex: {e}"))?;
+            set.entry(addr).code = Some(bytes);
+        }
+        for raw in &self.state {
+            let (addr, slot, value) = split_three(raw, "override-state", "ADDR:SLOT:VALUE")?;
+            set.entry(addr).state.insert(slot, value);
+        }
+        for raw in &self.state_diff {
+            let (addr, slot, value) =
+                split_three(raw, "override-state-diff", "ADDR:SLOT:VALUE")?;
+            set.entry(addr).state_diff.insert(slot, value);
+        }
+        for raw in &self.move_precompile {
+            let (addr, target) = split_two(raw, "override-move-precompile", "ADDR:TARGET")?;
+            set.entry(addr).move_precompile_to = Some(Address::from_str(target)?);
+        }
+
+        Ok(set)
+    }
+}
+
+fn split_two<'a>(
+    raw: &'a str,
+    flag: &str,
+    shape: &str,
+) -> eyre::Result<(Address, &'a str)> {
+    let (addr, rest) = raw
+        .split_once(':')
+        .ok_or_else(|| eyre::eyre!("--{flag} expects '{shape}', got '{raw}'"))?;
+    Ok((Address::from_str(addr.trim())?, rest.trim()))
+}
+
+fn split_three(
+    raw: &str,
+    flag: &str,
+    shape: &str,
+) -> eyre::Result<(Address, H256, U256)> {
+    let mut parts = raw.splitn(3, ':');
+    let addr = parts
+        .next()
+        .ok_or_else(|| eyre::eyre!("--{flag} expects '{shape}', got '{raw}'"))?;
+    let slot = parts
+        .next()
+        .ok_or_else(|| eyre::eyre!("--{flag} expects '{shape}', got '{raw}'"))?;
+    let value = parts
+        .next()
+        .ok_or_else(|| eyre::eyre!("--{flag} expects '{shape}', got '{raw}'"))?;
+    Ok((
+        Address::from_str(addr.trim())?,
+        parse_h256(slot.trim())?,
+        parse_u256(value.trim())?,
+    ))
+}
+
+fn parse_u64_flex(s: &str) -> eyre::Result<u64> {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix("0x") {
+        Ok(u64::from_str_radix(rest, 16)?)
+    } else {
+        Ok(s.parse::<u64>()?)
+    }
+}
+
+fn parse_h256(s: &str) -> eyre::Result<H256> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    if stripped.len() > 64 {
+        return Err(eyre::eyre!("slot '{s}' is more than 32 bytes"));
+    }
+    let padded = format!("{:0>64}", stripped);
+    let bytes = hex::decode(&padded)?;
+    Ok(H256::from_slice(&bytes))
 }
 
 #[derive(Parser, Clone)]

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -1,5 +1,14 @@
-use ethrex_common::{Address, U256};
-use ethrex_rpc::{EthClient, clients::EthClientError};
+use ethrex_common::{Address, Bytes, U256, types::TxKind};
+use ethrex_rpc::{
+    EthClient,
+    clients::{EthClientError, Overrides, eth::RpcResponse},
+    utils::RpcRequest,
+};
+use serde_json::{Value, json};
+
+pub mod state_override;
+
+pub use state_override::{AccountOverride, StateOverrideSet};
 
 // 0x70a08231 == balanceOf(address)
 pub const BALANCE_OF_SELECTOR: [u8; 4] = [0x70, 0xa0, 0x82, 0x31];
@@ -9,20 +18,85 @@ pub async fn get_token_balance(
     address: Address,
     token_address: Address,
 ) -> Result<U256, EthClientError> {
+    get_token_balance_with_state_overrides(
+        eth_client,
+        address,
+        token_address,
+        &StateOverrideSet::new(),
+    )
+    .await
+}
+
+pub async fn get_token_balance_with_state_overrides(
+    eth_client: &EthClient,
+    address: Address,
+    token_address: Address,
+    state_overrides: &StateOverrideSet,
+) -> Result<U256, EthClientError> {
     let mut calldata = Vec::from(BALANCE_OF_SELECTOR);
     calldata.resize(16, 0);
     calldata.extend(address.to_fixed_bytes());
-    U256::from_str_radix(
-        &eth_client
-            .call(
-                token_address,
-                calldata.into(),
-                ethrex_rpc::clients::Overrides::default(),
-            )
-            .await?,
-        16,
+    let raw = call_with_state_overrides(
+        eth_client,
+        token_address,
+        calldata.into(),
+        Overrides::default(),
+        state_overrides,
     )
-    .map_err(|_| {
+    .await?;
+    U256::from_str_radix(raw.trim_start_matches("0x"), 16).map_err(|_| {
         EthClientError::Custom(format!("Address {token_address} did not return a uint256"))
     })
+}
+
+/// Like [`EthClient::call`] but threads a State Override Set as the 3rd
+/// `eth_call` parameter. When `state_overrides` is empty, behaves like a normal
+/// 2-param `eth_call` so older nodes keep working.
+pub async fn call_with_state_overrides(
+    eth_client: &EthClient,
+    to: Address,
+    calldata: Bytes,
+    overrides: Overrides,
+    state_overrides: &StateOverrideSet,
+) -> Result<String, EthClientError> {
+    let mut tx_json = json!({
+        "to": format!("{to:#x}"),
+        "input": format!("0x{}", hex::encode(&calldata)),
+        "value": format!("{:#x}", overrides.value.unwrap_or_default()),
+        "from": format!("{:#x}", overrides.from.unwrap_or_default()),
+    });
+    if let Some(nonce) = overrides.nonce {
+        tx_json["nonce"] = json!(format!("{nonce:#x}"));
+    }
+    if let Some(gas) = overrides.gas_limit {
+        tx_json["gas"] = json!(format!("{gas:#x}"));
+    }
+    if let Some(price) = overrides.max_fee_per_gas {
+        tx_json["gasPrice"] = json!(format!("{price:#x}"));
+    }
+    let _ = TxKind::Call(to); // keep TxKind import meaningful for future variants
+
+    let block_param: Value = overrides
+        .block
+        .map(Into::into)
+        .unwrap_or_else(|| Value::String("latest".to_string()));
+
+    let mut params = vec![tx_json, block_param];
+    if !state_overrides.is_empty() {
+        params.push(state_overrides.to_rpc_value());
+    }
+
+    let request = RpcRequest::new("eth_call", Some(params));
+    match eth_client.send_request(request).await? {
+        RpcResponse::Success(result) => serde_json::from_value::<String>(result.result)
+            .map_err(|e| EthClientError::Custom(format!("eth_call decode failed: {e}"))),
+        RpcResponse::Error(err) => Err(EthClientError::Custom(format!(
+            "eth_call rpc error: {}{}",
+            err.error.message,
+            err.error
+                .data
+                .map(|d| format!(" (data: {d})"))
+                .unwrap_or_default()
+        ))),
+    }
 }

--- a/sdk/src/client/eth/state_override.rs
+++ b/sdk/src/client/eth/state_override.rs
@@ -1,0 +1,154 @@
+//! State override set for `eth_call` / `eth_estimateGas` / `eth_createAccessList`.
+//!
+//! JSON-RPC shape matches geth's State Override Set
+//! (<https://geth.ethereum.org/docs/interacting-with-geth/rpc/objects#state-override-set>),
+//! also supported by ethrex as of PR lambdaclass/ethrex#6660.
+
+use std::collections::BTreeMap;
+
+use ethrex_common::{Address, Bytes, H256, U256};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+/// Per-address state overlay. `state` and `state_diff` are mutually exclusive
+/// — supplying both produces an RPC error server-side.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct AccountOverride {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance: Option<U256>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<Bytes>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub state: BTreeMap<H256, U256>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", rename = "stateDiff")]
+    pub state_diff: BTreeMap<H256, U256>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "movePrecompileToAddress"
+    )]
+    pub move_precompile_to: Option<Address>,
+}
+
+/// State override set: address → [`AccountOverride`].
+///
+/// Serializes to the JSON shape expected as the 3rd parameter of `eth_call`:
+///
+/// ```json
+/// {
+///   "0xabc...": { "balance": "0x100", "nonce": "0x5" },
+///   "0xdef...": { "code": "0x600160005260206000f3" }
+/// }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct StateOverrideSet(pub BTreeMap<Address, AccountOverride>);
+
+impl StateOverrideSet {
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn entry(&mut self, address: Address) -> &mut AccountOverride {
+        self.0.entry(address).or_default()
+    }
+
+    /// Render to the JSON form geth/ethrex expect. Values are emitted as hex
+    /// strings (`balance`, `nonce`, `code`, storage slot keys/values).
+    pub fn to_rpc_value(&self) -> Value {
+        let mut out = serde_json::Map::new();
+        for (addr, ov) in &self.0 {
+            let mut entry = serde_json::Map::new();
+            if let Some(balance) = ov.balance {
+                entry.insert("balance".into(), json!(format!("{balance:#x}")));
+            }
+            if let Some(nonce) = ov.nonce {
+                entry.insert("nonce".into(), json!(format!("{nonce:#x}")));
+            }
+            if let Some(code) = &ov.code {
+                entry.insert("code".into(), json!(format!("0x{}", hex::encode(code))));
+            }
+            if !ov.state.is_empty() {
+                let mut storage = serde_json::Map::new();
+                for (slot, value) in &ov.state {
+                    storage.insert(format!("{slot:#x}"), json!(format!("{value:#x}")));
+                }
+                entry.insert("state".into(), Value::Object(storage));
+            }
+            if !ov.state_diff.is_empty() {
+                let mut storage = serde_json::Map::new();
+                for (slot, value) in &ov.state_diff {
+                    storage.insert(format!("{slot:#x}"), json!(format!("{value:#x}")));
+                }
+                entry.insert("stateDiff".into(), Value::Object(storage));
+            }
+            if let Some(target) = ov.move_precompile_to {
+                entry.insert("movePrecompileToAddress".into(), json!(format!("{target:#x}")));
+            }
+            out.insert(format!("{addr:#x}"), Value::Object(entry));
+        }
+        Value::Object(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(hex: &str) -> Address {
+        hex.parse().unwrap()
+    }
+
+    #[test]
+    fn empty_set_serializes_to_empty_object() {
+        let set = StateOverrideSet::new();
+        assert_eq!(set.to_rpc_value(), json!({}));
+    }
+
+    #[test]
+    fn balance_and_nonce_serialize_as_hex() {
+        let mut set = StateOverrideSet::new();
+        let a = addr("0x000000000000000000000000000000000000beef");
+        let entry = set.entry(a);
+        entry.balance = Some(U256::from(0x100u64));
+        entry.nonce = Some(5);
+        assert_eq!(
+            set.to_rpc_value(),
+            json!({
+                "0x000000000000000000000000000000000000beef": {
+                    "balance": "0x100",
+                    "nonce": "0x5"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn code_serializes_with_0x_prefix() {
+        let mut set = StateOverrideSet::new();
+        let a = addr("0x00000000000000000000000000000000000000aa");
+        set.entry(a).code = Some(Bytes::from_static(&[0x60, 0x01, 0x60, 0x02]));
+        assert_eq!(
+            set.to_rpc_value(),
+            json!({
+                "0x00000000000000000000000000000000000000aa": { "code": "0x60016002" }
+            })
+        );
+    }
+
+    #[test]
+    fn state_diff_renders_slot_map() {
+        let mut set = StateOverrideSet::new();
+        let a = addr("0x00000000000000000000000000000000000000cc");
+        let slot = H256::from_low_u64_be(1);
+        set.entry(a).state_diff.insert(slot, U256::from(0xaau64));
+        let v = set.to_rpc_value();
+        let entry = v.get("0x00000000000000000000000000000000000000cc").unwrap();
+        let diff = entry.get("stateDiff").unwrap().as_object().unwrap();
+        assert!(diff.contains_key(&format!("{slot:#x}")));
+    }
+}

--- a/sdk/src/client/eth/state_override.rs
+++ b/sdk/src/client/eth/state_override.rs
@@ -87,7 +87,10 @@ impl StateOverrideSet {
                 entry.insert("stateDiff".into(), Value::Object(storage));
             }
             if let Some(target) = ov.move_precompile_to {
-                entry.insert("movePrecompileToAddress".into(), json!(format!("{target:#x}")));
+                entry.insert(
+                    "movePrecompileToAddress".into(),
+                    json!(format!("{target:#x}")),
+                );
             }
             out.insert(format!("{addr:#x}"), Value::Object(entry));
         }


### PR DESCRIPTION
Add geth-compatible _State Override Set_ as the 3rd `eth_call` parameter on `rex call` and `rex balance --token`, matching the format ethrex implements in lambdaclass/ethrex#6660. 

New repeatable flags (each scoped per address) cover `--override-balance`, `--override-nonce`, `--override-code`, `--override-state`, `--override-state-diff`, `--override-move-precompile`. Multiple flags compose into one State Override Set in a single call; when no override flags are passed the 2-parameter `eth_call` form is used so older nodes keep working.