### PR TITLE
fix(ci): use `--locked` for `cargo install cargo-chef`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --locked
 
 WORKDIR /rex
 


### PR DESCRIPTION
The CI step that builds the docker image was failing with the following error:

```
Dockerfile:10
--------------------
   8 |         ca-certificates \
   9 |         && rm -rf /var/lib/apt/lists/*
  10 | >>> RUN cargo install cargo-chef
  11 |     
  12 |     WORKDIR /rex
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cargo install cargo-chef" did not complete successfully: exit code: 101
```

This was caused by the following dependency chain:

```
host rustc 1.90.0
     └── cargo-chef@0.1.77
                   └── cargo-manifest@0.20.0
                                 └── cargo-platform@0.3.3   ← published with rust-version = 1.91
```

By having cargo-chef installation locked, the dependency tree is not built independently, it uses the lockfile instead to reuse already locked versions, including the rustc one.

This PR fixes the CI step.