### PR TITLE
feat(cli,sdk): support eth_call block overrides

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -11,6 +11,7 @@
     - [`rex call`](#rex-call)
       - [State overrides](#state-overrides)
         - [Stacking multiple overrides](#stacking-multiple-overrides)
+      - [Block overrides](#block-overrides)
     - [`rex chain-id`](#rex-chain-id)
     - [`rex code`](#rex-code)
     - [`rex create-address`](#rex-create-address)
@@ -131,10 +132,18 @@ Options:
       --override-state <ADDR:SLOT:VALUE>            Replace a storage slot for this call.
       --override-state-diff <ADDR:SLOT:VALUE>       Overlay a storage slot for this call.
       --override-move-precompile <ADDR:TARGET>      Relocate a precompile to a different address.
+      --override-block-number <NUMBER>              Override the block number for this call (see [Block overrides](#block-overrides)).
+      --override-block-time <TIMESTAMP>             Override the block timestamp.
+      --override-block-gas-limit <GAS>              Override the block gas limit.
+      --override-block-coinbase <ADDR>              Override the block coinbase (fee recipient).
+      --override-block-prev-randao <HASH>           Override PREVRANDAO.
+      --override-block-base-fee <VALUE>             Override the block base fee per gas.
+      --override-block-blob-base-fee <VALUE>        Override the blob base fee per gas.
+      --override-block-difficulty <VALUE>           Override the block difficulty.
   -h, --help                                        Print help
 ```
 
-State overrides require the token form (`--token`); plain ETH balance reads use `eth_getBalance`, which does not accept overrides.
+State and block overrides require the token form (`--token`); plain ETH balance reads use `eth_getBalance`, which does not accept overrides.
 
 ### `rex block-number`
 
@@ -173,6 +182,14 @@ Options:
       --override-state <ADDR:SLOT:VALUE>            Replace a storage slot for this call.
       --override-state-diff <ADDR:SLOT:VALUE>       Overlay a storage slot for this call.
       --override-move-precompile <ADDR:TARGET>      Relocate a precompile to a different address.
+      --override-block-number <NUMBER>              Override the block number for this call (see [Block overrides](#block-overrides)).
+      --override-block-time <TIMESTAMP>             Override the block timestamp.
+      --override-block-gas-limit <GAS>              Override the block gas limit.
+      --override-block-coinbase <ADDR>              Override the block coinbase (fee recipient).
+      --override-block-prev-randao <HASH>           Override PREVRANDAO.
+      --override-block-base-fee <VALUE>             Override the block base fee per gas.
+      --override-block-blob-base-fee <VALUE>        Override the blob base fee per gas.
+      --override-block-difficulty <VALUE>           Override the block difficulty.
   -h, --help                                        Print help
 ```
 
@@ -233,6 +250,51 @@ rex call 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
          --override-state-diff 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48:0x9254cb65314db3d2d7ca17f753f1d9c7f1b6fa05111d18d10ed5b9519d1b247c:0x42 \
          --override-balance 0x0000000000000000000000000000000000000bad:0x100 \
          --override-nonce   0x0000000000000000000000000000000000000bad:0x7
+```
+
+#### Block overrides
+
+`rex call` and `rex balance --token …` also accept a Block Override Set as the 4th `eth_call` parameter, matching the format documented at <https://geth.ethereum.org/docs/interacting-with-geth/rpc/objects#block-overrides> (also implemented in ethrex as of
+[lambdaclass/ethrex#6660](https://github.com/lambdaclass/ethrex/pull/6660)).
+
+Each flag replaces one field of the block header the call is simulated against; omitted fields keep the real header values. Unlike state override flags, each flag takes a single value — there is only one block context per call. Numeric values accept hex (`0x…`) or decimal.
+
+| Flag | Format | JSON field | Meaning |
+|---|---|---|---|
+| `--override-block-number` | `NUMBER` | `number` | Block number (`block.number`). |
+| `--override-block-time` | `TIMESTAMP` | `time` | Block timestamp in unix seconds (`block.timestamp`). |
+| `--override-block-gas-limit` | `GAS` | `gasLimit` | Block gas limit. |
+| `--override-block-coinbase` | `ADDR` | `coinbase` | Fee recipient (`block.coinbase`). Alias: `--override-block-fee-recipient`. |
+| `--override-block-prev-randao` | `HASH` | `random` | PREVRANDAO value (`block.prevrandao`). Alias: `--override-block-random`. |
+| `--override-block-base-fee` | `VALUE` | `baseFeePerGas` | Base fee per gas (EIP-1559). |
+| `--override-block-blob-base-fee` | `VALUE` | `blobBaseFeePerGas` | Blob base fee per gas (EIP-4844). |
+| `--override-block-difficulty` | `VALUE` | `difficulty` | Block difficulty; a no-op on post-merge blocks. |
+
+Block and state overrides compose freely in one invocation. When only block override flags are passed, an empty state override object (a no-op) is sent as the 3rd parameter to keep the block override set in 4th position; when neither is passed, the 2-parameter `eth_call` form is used so older nodes keep working.
+
+> [!NOTE]
+> The JSON field names follow ethrex and reth (`coinbase`, `random`, `blobBaseFeePerGas`). Recent geth releases renamed these three to `feeRecipient`, `prevRandao` and `blobBaseFee` and silently ignore the older spellings, so against a current geth node those three overrides won't take effect.
+
+Examples:
+
+```bash
+# Simulate a call one year in the future, e.g. to check that a vesting
+# contract releases funds after its cliff
+rex call 0x00000000000000000000000000000000000ce11a \
+         --calldata 0x86d1a69f \
+         --override-block-time 1812837600 \
+         --override-block-number 25000000
+
+# Query an ERC-20 balance under a synthetic block context
+rex balance --token 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 \
+            0x37305b1cd40574e4c5ce33f8e8306be057fd7341 \
+            --override-block-number 0x1312d00
+
+# Combine state and block overrides in one call
+rex call 0x00000000000000000000000000000000000ce11a \
+         --calldata 0x86d1a69f \
+         --override-balance 0x0000000000000000000000000000000000000bad:0x100 \
+         --override-block-coinbase 0x000000000000000000000000000000000000cafe
 ```
 
 ### `rex chain-id`

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::commands::{frame, l2, wallet};
-use crate::common::{AuthorizeArgs, StateOverrideArgs};
+use crate::common::{AuthorizeArgs, BlockOverrideArgs, StateOverrideArgs};
 use crate::utils::{
     encode_constructor_args, parse_contract_creation, parse_func_call, parse_hex, parse_hex_string,
 };
@@ -27,7 +27,7 @@ use ethrex_sdk::{compile_contract, git_clone};
 use keccak_hash::keccak;
 use rex_sdk::authorize::build_authorization_tuple;
 use rex_sdk::client::eth::{
-    call_with_state_overrides, get_token_balance, get_token_balance_with_state_overrides,
+    call_with_overrides, get_token_balance, get_token_balance_with_overrides,
 };
 use rex_sdk::create::{
     DETERMINISTIC_DEPLOYER, brute_force_create2, compute_create_address, compute_create2_address,
@@ -93,6 +93,8 @@ pub(crate) enum Command {
         rpc_url: Url,
         #[clap(flatten)]
         state_overrides: StateOverrideArgs,
+        #[clap(flatten)]
+        block_overrides: BlockOverrideArgs,
     },
     #[clap(about = "Get the current block_number.", visible_alias = "bl")]
     BlockNumber {
@@ -318,25 +320,26 @@ impl Command {
                 eth,
                 rpc_url,
                 state_overrides,
+                block_overrides,
             } => {
                 let eth_client = EthClient::new(rpc_url)?;
                 let account_balance = if let Some(token_address) = token_address {
-                    if state_overrides.is_empty() {
+                    if state_overrides.is_empty() && block_overrides.is_empty() {
                         get_token_balance(&eth_client, account, token_address).await?
                     } else {
-                        let overrides = state_overrides.build()?;
-                        get_token_balance_with_state_overrides(
+                        get_token_balance_with_overrides(
                             &eth_client,
                             account,
                             token_address,
-                            &overrides,
+                            &state_overrides.build()?,
+                            &block_overrides.build(),
                         )
                         .await?
                     }
                 } else {
-                    if !state_overrides.is_empty() {
+                    if !state_overrides.is_empty() || !block_overrides.is_empty() {
                         return Err(eyre::eyre!(
-                            "state overrides apply to contract calls (eth_call); use --token to query an ERC-20 balance with overrides, since eth_getBalance does not accept overrides"
+                            "state/block overrides apply to contract calls (eth_call); use --token to query an ERC-20 balance with overrides, since eth_getBalance does not accept overrides"
                         ));
                     }
                     eth_client
@@ -626,16 +629,16 @@ impl Command {
                     ..Default::default()
                 };
 
-                let result = if args.state_overrides.is_empty() {
+                let result = if args.state_overrides.is_empty() && args.block_overrides.is_empty() {
                     client.call(args.to, calldata, call_overrides).await?
                 } else {
-                    let state_overrides = args.state_overrides.build()?;
-                    call_with_state_overrides(
+                    call_with_overrides(
                         &client,
                         args.to,
                         calldata,
                         call_overrides,
-                        &state_overrides,
+                        &args.state_overrides.build()?,
+                        &args.block_overrides.build(),
                     )
                     .await?
                 };

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -575,6 +575,7 @@ impl Command {
                         eth: args.eth,
                         rpc_url,
                         state_overrides: Default::default(),
+                        block_overrides: Default::default(),
                     }
                     .run()
                     .await

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::utils::{parse_hex, parse_private_key, parse_u256};
 use clap::Parser;
 use ethrex_common::{Address, Bytes, H256, Secret, U256};
-use rex_sdk::client::eth::StateOverrideSet;
+use rex_sdk::client::eth::{BlockOverrideSet, StateOverrideSet};
 use secp256k1::SecretKey;
 
 #[derive(Parser)]
@@ -146,6 +146,8 @@ pub struct CallArgs {
     pub explorer_url: bool,
     #[clap(flatten)]
     pub state_overrides: StateOverrideArgs,
+    #[clap(flatten)]
+    pub block_overrides: BlockOverrideArgs,
     #[clap(required = false)]
     pub _args: Vec<String>,
 }
@@ -235,6 +237,97 @@ impl StateOverrideArgs {
         }
 
         Ok(set)
+    }
+}
+
+/// Block Override Set (geth-style, ethrex PR #6660). Each flag replaces one
+/// field of the block header the call is simulated against; omitted fields
+/// keep the real header values. Empty by default; when no flags are passed,
+/// no 4th `eth_call` parameter is sent.
+#[derive(Parser, Default, Clone, Debug)]
+pub struct BlockOverrideArgs {
+    #[clap(
+        long = "override-block-number",
+        value_name = "NUMBER",
+        value_parser = parse_u64_flex,
+        help = "Override the block number. Hex (0x…) or decimal."
+    )]
+    pub number: Option<u64>,
+    #[clap(
+        long = "override-block-time",
+        value_name = "TIMESTAMP",
+        value_parser = parse_u64_flex,
+        help = "Override the block timestamp (unix seconds). Hex (0x…) or decimal."
+    )]
+    pub time: Option<u64>,
+    #[clap(
+        long = "override-block-gas-limit",
+        value_name = "GAS",
+        value_parser = parse_u64_flex,
+        help = "Override the block gas limit. Hex (0x…) or decimal."
+    )]
+    pub block_gas_limit: Option<u64>,
+    #[clap(
+        long = "override-block-coinbase",
+        visible_alias = "override-block-fee-recipient",
+        value_name = "ADDR",
+        help = "Override the block coinbase (fee recipient)."
+    )]
+    pub coinbase: Option<Address>,
+    #[clap(
+        long = "override-block-prev-randao",
+        visible_alias = "override-block-random",
+        value_name = "HASH",
+        value_parser = parse_h256,
+        help = "Override PREVRANDAO. Up to 32-byte hex, left-padded."
+    )]
+    pub prev_randao: Option<H256>,
+    #[clap(
+        long = "override-block-base-fee",
+        value_name = "VALUE",
+        value_parser = parse_u64_flex,
+        help = "Override the block base fee per gas. Hex (0x…) or decimal."
+    )]
+    pub base_fee_per_gas: Option<u64>,
+    #[clap(
+        long = "override-block-blob-base-fee",
+        value_name = "VALUE",
+        value_parser = parse_u256,
+        help = "Override the blob base fee per gas. Hex (0x…) or decimal."
+    )]
+    pub blob_base_fee_per_gas: Option<U256>,
+    #[clap(
+        long = "override-block-difficulty",
+        value_name = "VALUE",
+        value_parser = parse_u256,
+        help = "Override the block difficulty (pre-merge chains). Hex (0x…) or decimal."
+    )]
+    pub difficulty: Option<U256>,
+}
+
+impl BlockOverrideArgs {
+    pub fn is_empty(&self) -> bool {
+        self.number.is_none()
+            && self.time.is_none()
+            && self.block_gas_limit.is_none()
+            && self.coinbase.is_none()
+            && self.prev_randao.is_none()
+            && self.base_fee_per_gas.is_none()
+            && self.blob_base_fee_per_gas.is_none()
+            && self.difficulty.is_none()
+    }
+
+    pub fn build(&self) -> BlockOverrideSet {
+        BlockOverrideSet {
+            number: self.number,
+            time: self.time,
+            gas_limit: self.block_gas_limit,
+            coinbase: self.coinbase,
+            random: self.prev_randao,
+            base_fee_per_gas: self.base_fee_per_gas,
+            blob_base_fee_per_gas: self.blob_base_fee_per_gas,
+            difficulty: self.difficulty,
+        }
     }
 }
 

--- a/sdk/src/client/eth/block_override.rs
+++ b/sdk/src/client/eth/block_override.rs
@@ -1,0 +1,154 @@
+//! Block override set for `eth_call` / `eth_estimateGas`.
+//!
+//! JSON-RPC shape matches geth's Block Override Set
+//! (<https://geth.ethereum.org/docs/interacting-with-geth/rpc/objects#block-overrides>),
+//! also supported by ethrex as of PR lambdaclass/ethrex#6660. Field names follow
+//! the spelling ethrex and reth/alloy accept (`coinbase`, `random`,
+//! `blobBaseFeePerGas`); recent geth renamed those to `feeRecipient`,
+//! `prevRandao` and `blobBaseFee`.
+
+use ethrex_common::{Address, H256, U256};
+use serde_json::{Value, json};
+
+/// Block override set: each field, when present, replaces the corresponding
+/// header field of the block the call is simulated against. Omitted fields keep
+/// the real header values.
+///
+/// Serializes to the JSON shape expected as the 4th parameter of `eth_call`:
+///
+/// ```json
+/// {
+///   "number": "0x1234",
+///   "time": "0x665f0d00",
+///   "coinbase": "0xabc..."
+/// }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct BlockOverrideSet {
+    pub number: Option<u64>,
+    pub time: Option<u64>,
+    pub gas_limit: Option<u64>,
+    pub coinbase: Option<Address>,
+    /// Override for PREVRANDAO.
+    pub random: Option<H256>,
+    pub base_fee_per_gas: Option<u64>,
+    pub blob_base_fee_per_gas: Option<U256>,
+    /// No-op on post-merge blocks.
+    pub difficulty: Option<U256>,
+}
+
+impl BlockOverrideSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.number.is_none()
+            && self.time.is_none()
+            && self.gas_limit.is_none()
+            && self.coinbase.is_none()
+            && self.random.is_none()
+            && self.base_fee_per_gas.is_none()
+            && self.blob_base_fee_per_gas.is_none()
+            && self.difficulty.is_none()
+    }
+
+    /// Render to the JSON form geth/ethrex expect. Numeric values are emitted
+    /// as hex strings; `random` as a 32-byte hash.
+    pub fn to_rpc_value(&self) -> Value {
+        let mut out = serde_json::Map::new();
+        if let Some(number) = self.number {
+            out.insert("number".into(), json!(format!("{number:#x}")));
+        }
+        if let Some(time) = self.time {
+            out.insert("time".into(), json!(format!("{time:#x}")));
+        }
+        if let Some(gas_limit) = self.gas_limit {
+            out.insert("gasLimit".into(), json!(format!("{gas_limit:#x}")));
+        }
+        if let Some(coinbase) = self.coinbase {
+            out.insert("coinbase".into(), json!(format!("{coinbase:#x}")));
+        }
+        if let Some(random) = self.random {
+            out.insert("random".into(), json!(format!("{random:#x}")));
+        }
+        if let Some(base_fee) = self.base_fee_per_gas {
+            out.insert("baseFeePerGas".into(), json!(format!("{base_fee:#x}")));
+        }
+        if let Some(blob_base_fee) = self.blob_base_fee_per_gas {
+            out.insert(
+                "blobBaseFeePerGas".into(),
+                json!(format!("{blob_base_fee:#x}")),
+            );
+        }
+        if let Some(difficulty) = self.difficulty {
+            out.insert("difficulty".into(), json!(format!("{difficulty:#x}")));
+        }
+        Value::Object(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_set_serializes_to_empty_object() {
+        let set = BlockOverrideSet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.to_rpc_value(), json!({}));
+    }
+
+    #[test]
+    fn numeric_fields_serialize_as_hex() {
+        let set = BlockOverrideSet {
+            number: Some(0x1234),
+            time: Some(1_700_000_000),
+            gas_limit: Some(30_000_000),
+            base_fee_per_gas: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(
+            set.to_rpc_value(),
+            json!({
+                "number": "0x1234",
+                "time": "0x6553f100",
+                "gasLimit": "0x1c9c380",
+                "baseFeePerGas": "0x7"
+            })
+        );
+    }
+
+    #[test]
+    fn coinbase_and_random_serialize_full_width() {
+        let set = BlockOverrideSet {
+            coinbase: Some(
+                "0x000000000000000000000000000000000000beef"
+                    .parse()
+                    .unwrap(),
+            ),
+            random: Some(H256::from_low_u64_be(1)),
+            ..Default::default()
+        };
+        assert_eq!(
+            set.to_rpc_value(),
+            json!({
+                "coinbase": "0x000000000000000000000000000000000000beef",
+                "random": "0x0000000000000000000000000000000000000000000000000000000000000001"
+            })
+        );
+    }
+
+    #[test]
+    fn blob_base_fee_and_difficulty_serialize_as_hex() {
+        let set = BlockOverrideSet {
+            blob_base_fee_per_gas: Some(U256::from(0xaau64)),
+            difficulty: Some(U256::from(0x42u64)),
+            ..Default::default()
+        };
+        assert_eq!(
+            set.to_rpc_value(),
+            json!({ "blobBaseFeePerGas": "0xaa", "difficulty": "0x42" })
+        );
+    }
+}

--- a/sdk/src/client/eth/mod.rs
+++ b/sdk/src/client/eth/mod.rs
@@ -6,8 +6,10 @@ use ethrex_rpc::{
 };
 use serde_json::{Value, json};
 
+pub mod block_override;
 pub mod state_override;
 
+pub use block_override::BlockOverrideSet;
 pub use state_override::{AccountOverride, StateOverrideSet};
 
 // 0x70a08231 == balanceOf(address)
@@ -18,11 +20,12 @@ pub async fn get_token_balance(
     address: Address,
     token_address: Address,
 ) -> Result<U256, EthClientError> {
-    get_token_balance_with_state_overrides(
+    get_token_balance_with_overrides(
         eth_client,
         address,
         token_address,
         &StateOverrideSet::new(),
+        &BlockOverrideSet::new(),
     )
     .await
 }
@@ -33,15 +36,33 @@ pub async fn get_token_balance_with_state_overrides(
     token_address: Address,
     state_overrides: &StateOverrideSet,
 ) -> Result<U256, EthClientError> {
+    get_token_balance_with_overrides(
+        eth_client,
+        address,
+        token_address,
+        state_overrides,
+        &BlockOverrideSet::new(),
+    )
+    .await
+}
+
+pub async fn get_token_balance_with_overrides(
+    eth_client: &EthClient,
+    address: Address,
+    token_address: Address,
+    state_overrides: &StateOverrideSet,
+    block_overrides: &BlockOverrideSet,
+) -> Result<U256, EthClientError> {
     let mut calldata = Vec::from(BALANCE_OF_SELECTOR);
     calldata.resize(16, 0);
     calldata.extend(address.to_fixed_bytes());
-    let raw = call_with_state_overrides(
+    let raw = call_with_overrides(
         eth_client,
         token_address,
         calldata.into(),
         Overrides::default(),
         state_overrides,
+        block_overrides,
     )
     .await?;
     U256::from_str_radix(raw.trim_start_matches("0x"), 16).map_err(|_| {
@@ -58,6 +79,31 @@ pub async fn call_with_state_overrides(
     calldata: Bytes,
     overrides: Overrides,
     state_overrides: &StateOverrideSet,
+) -> Result<String, EthClientError> {
+    call_with_overrides(
+        eth_client,
+        to,
+        calldata,
+        overrides,
+        state_overrides,
+        &BlockOverrideSet::new(),
+    )
+    .await
+}
+
+/// Like [`EthClient::call`] but threads a State Override Set and a Block
+/// Override Set as the 3rd and 4th `eth_call` parameters. Trailing empty sets
+/// are omitted, so with both empty this behaves like a normal 2-param
+/// `eth_call` and older nodes keep working. When only block overrides are
+/// given, an empty object (a no-op) is sent as the 3rd parameter to keep the
+/// 4th in position.
+pub async fn call_with_overrides(
+    eth_client: &EthClient,
+    to: Address,
+    calldata: Bytes,
+    overrides: Overrides,
+    state_overrides: &StateOverrideSet,
+    block_overrides: &BlockOverrideSet,
 ) -> Result<String, EthClientError> {
     let mut tx_json = json!({
         "to": format!("{to:#x}"),
@@ -82,8 +128,11 @@ pub async fn call_with_state_overrides(
         .unwrap_or_else(|| Value::String("latest".to_string()));
 
     let mut params = vec![tx_json, block_param];
-    if !state_overrides.is_empty() {
+    if !state_overrides.is_empty() || !block_overrides.is_empty() {
         params.push(state_overrides.to_rpc_value());
+    }
+    if !block_overrides.is_empty() {
+        params.push(block_overrides.to_rpc_value());
     }
 
     let request = RpcRequest::new("eth_call", Some(params));

--- a/sdk/src/client/eth/state_override.rs
+++ b/sdk/src/client/eth/state_override.rs
@@ -57,8 +57,10 @@ impl StateOverrideSet {
         self.0.entry(address).or_default()
     }
 
-    /// Render to the JSON form geth/ethrex expect. Values are emitted as hex
-    /// strings (`balance`, `nonce`, `code`, storage slot keys/values).
+    /// Render to the JSON form geth/ethrex expect. `balance` and `nonce` are
+    /// emitted as minimal hex; storage slot keys and values as full 32-byte
+    /// words, since geth/anvil deserialize them into 32-byte hashes and reject
+    /// shorter hex.
     pub fn to_rpc_value(&self) -> Value {
         let mut out = serde_json::Map::new();
         for (addr, ov) in &self.0 {
@@ -75,14 +77,14 @@ impl StateOverrideSet {
             if !ov.state.is_empty() {
                 let mut storage = serde_json::Map::new();
                 for (slot, value) in &ov.state {
-                    storage.insert(format!("{slot:#x}"), json!(format!("{value:#x}")));
+                    storage.insert(format!("{slot:#x}"), json!(format!("{value:#066x}")));
                 }
                 entry.insert("state".into(), Value::Object(storage));
             }
             if !ov.state_diff.is_empty() {
                 let mut storage = serde_json::Map::new();
                 for (slot, value) in &ov.state_diff {
-                    storage.insert(format!("{slot:#x}"), json!(format!("{value:#x}")));
+                    storage.insert(format!("{slot:#x}"), json!(format!("{value:#066x}")));
                 }
                 entry.insert("stateDiff".into(), Value::Object(storage));
             }
@@ -152,6 +154,31 @@ mod tests {
         let v = set.to_rpc_value();
         let entry = v.get("0x00000000000000000000000000000000000000cc").unwrap();
         let diff = entry.get("stateDiff").unwrap().as_object().unwrap();
-        assert!(diff.contains_key(&format!("{slot:#x}")));
+        assert_eq!(
+            diff.get(&format!("{slot:#x}")).unwrap(),
+            "0x00000000000000000000000000000000000000000000000000000000000000aa"
+        );
+    }
+
+    #[test]
+    fn storage_values_serialize_as_full_32_byte_words() {
+        // geth/anvil deserialize `state`/`stateDiff` values into 32-byte
+        // hashes; minimal hex like "0x0" is rejected ("odd number of digits").
+        let mut set = StateOverrideSet::new();
+        let a = addr("0x00000000000000000000000000000000000000dd");
+        set.entry(a)
+            .state
+            .insert(H256::from_low_u64_be(2), U256::zero());
+        assert_eq!(
+            set.to_rpc_value(),
+            json!({
+                "0x00000000000000000000000000000000000000dd": {
+                    "state": {
+                        "0x0000000000000000000000000000000000000000000000000000000000000002":
+                        "0x0000000000000000000000000000000000000000000000000000000000000000"
+                    }
+                }
+            })
+        );
     }
 }


### PR DESCRIPTION
**Motivation**

#230 added the State Override Set (3rd `eth_call` parameter); this completes the pair with the Block Override Set (4th parameter), so calls can be simulated under a synthetic block context — e.g. checking a vesting/timelock contract at a future timestamp, or pricing under a different base fee.

**Description**

Add geth-compatible _Block Override Set_ as the 4th `eth_call` parameter on `rex call` and `rex balance --token`, matching the format ethrex implements in lambdaclass/ethrex#6660.

- **SDK**: new `BlockOverrideSet` (`number`, `time`, `gasLimit`, `coinbase`, `random`, `baseFeePerGas`, `blobBaseFeePerGas`, `difficulty`) plus `call_with_overrides` / `get_token_balance_with_overrides` taking both override sets; the existing `*_with_state_overrides` functions delegate to them, so the SDK API stays backward compatible.
- **CLI**: new single-value flags `--override-block-number`, `--override-block-time`, `--override-block-gas-limit`, `--override-block-coinbase` (alias `--override-block-fee-recipient`), `--override-block-prev-randao` (alias `--override-block-random`), `--override-block-base-fee`, `--override-block-blob-base-fee`, `--override-block-difficulty`. Numeric values accept hex or decimal.

Block and state overrides compose in one call; when only block overrides are passed, an empty state override set (a no-op) is sent as the 3rd parameter to keep the 4th in position, and when neither is passed the 2-parameter `eth_call` form is used so older nodes keep working.