### PR TITLE
chore(cli,sdk): bump ethrex version to v14.0.0

### DIFF
--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v13.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v14.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v13.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v14.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,8 +1254,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1276,8 +1276,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1306,8 +1306,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1330,8 +1330,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1349,8 +1349,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "axum",
  "bytes",
@@ -1380,8 +1380,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1398,8 +1398,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1414,8 +1414,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1458,8 +1458,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1468,8 +1468,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1507,8 +1507,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1532,8 +1532,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "thiserror 2.0.17",
  "tracing",
@@ -1541,8 +1541,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1563,8 +1563,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1579,8 +1579,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1598,8 +1598,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "12.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?tag=v13.0.0#6e627ac5feb4465abc83f51ade43749ce2bf78db"
+version = "14.0.0"
+source = "git+https://github.com/lambdaclass/ethrex?tag=v14.0.0#52eadf52b38a0cfa0e222aac3ee9cbfc5112784a"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "13.0.0"
+version = "14.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "13.0.0"
+version = "14.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "13.0.0"
+version = "14.0.0"
 edition = "2024"
 
 [workspace.lints.rust]
@@ -29,13 +29,13 @@ manual_saturating_arithmetic = "warn"
 rex-cli = { path = "cli" }
 rex-sdk = { path = "sdk" }
 
-ethrex-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-common", tag = "v13.0.0" }
-ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-blockchain", tag = "v13.0.0" }
-ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rlp", tag = "v13.0.0" }
-ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rpc", tag = "v13.0.0" }
-ethrex-l2-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-rpc", tag = "v13.0.0" }
-ethrex-sdk = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-sdk", tag = "v13.0.0" }
-ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-common", tag = "v13.0.0" }
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-common", tag = "v14.0.0" }
+ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-blockchain", tag = "v14.0.0" }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rlp", tag = "v14.0.0" }
+ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rpc", tag = "v14.0.0" }
+ethrex-l2-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-rpc", tag = "v14.0.0" }
+ethrex-sdk = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-sdk", tag = "v14.0.0" }
+ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-common", tag = "v14.0.0" }
 
 keccak-hash = "0.11.0"
 thiserror = "2.0.11"


### PR DESCRIPTION
**Motivation**

rex releases must stay paired with ethrex releases. Fifth bump of the catch-up series (v10.0.0 → v16.0.0).

**Description**

- Bump the ethrex dependency tags from `v13.0.0` to `v14.0.0` (and regenerate `Cargo.lock`).
- Bump the ethrex binary used by the CI integration tests to v14.0.0.
- Bump the workspace version to 14.0.0 for the upcoming v14.0.0 release.
- No breaking changes affect rex's API surface (verified against the ethrex v13.0.0→v14.0.0 diff); no code changes needed.