### PR TITLE
chore(cli,sdk): bump ethrex version to v18.0.0

### DIFF
--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v16.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v18.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v16.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v18.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bb71d49ebc59181d73c9b6d64cc79255902dff099ca2db1cb3dc77fd347ae3"
+checksum = "f425381a3b5d1e4e7a9cfdddfcc14d62f70a9d5caffb8589e73851374840f366"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e20ad08dc26dffc61d7e4346d60fdd4f4b8ebbe8468e836367de7e0ec1e861"
+checksum = "0221ee5723272ab439785ee1eebf43b960db7d81c438bc8bd2a8be8f801d4dae"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c34883c327a09be736e72f84ef7d1e795542ed3ff2d08a8eb7193fbf6b5e052"
+checksum = "e38bf0a1fb41edea3fc79c551aea0d161d715505afdc76284e2101f50e99c4ee"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441fbd3261e5d7a255fb9a1c5bbe53f46f2e762b399ddab1434bb18e92f49467"
+checksum = "e274b0c18a40b82a4d491bcf22eece971026a44c894a9e9cb565ecaed02072c3"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40497a486e96e69644e74420573391e280a57cafef8ec7802935bc436ebe9afc"
+checksum = "1002c33e1a8bbed4a0c233d25fe17a28e697184da22e53976a71112d36397012"
 dependencies = [
  "axum",
  "bytes",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f9ace81a6afa64584b1cccf703345194d2e89fcddba0d8662452bdc5918d90"
+checksum = "4f647014431f627624ed69433b545df62af66c06b961630c333a00cf4341dcf5"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed28d88f40a83e930dac55b8f47d92a5b545df39b927aa85b38da01b1ad7230f"
+checksum = "d664e28bd0fd4a53b1aefe525f238899cc784c74e5f8462723c8662af2995580"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d303eaf65d4b336029649cbd095d947cdc9f47e6c0a2b4121d06f29c2af26d33"
+checksum = "fb5ea4f3aaea9129254e1c19506c4571c8a4ac1d9cd199b140d87b318abd8795"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda0d1ff8e555b03931c3a7118c3c0b06001ab50c77251d0c5e2092e0075ae05"
+checksum = "a3899a67433164d3954baeb123bcbedcb5229d9cb5a09f949a264e367ed61d55"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d550dc368e97a5b93a66f3185df48e86c1b2415444cfd11b20a0b690f6470279"
+checksum = "be4b370d218f7fb24be540a1f8fe3dd50d629cecbe75b899bd4d66d64f0fe19c"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2668950ac21b7055347f7b7a0ce26c6d290338b8a47da533c166ae175a75a14"
+checksum = "069b37b915a1a2f1f3afc4e516d3120cfd69e7ae11bf41b2a1e2d72de0a71cb5"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3359b890d8667541527655beaccde99233258c5e26e8970cd286e2db35b1b5b5"
+checksum = "7c32b6b6050fde3855cf616f4ac271754456f4f3359e480186b1c95901b60a8e"
 dependencies = [
  "thiserror 2.0.17",
  "tracing",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8647fc738e827d9bb4ca7081bcd5fbcd0d19d6dfc714c805654e2f1eac8d169c"
+checksum = "dbfea8e7d6c94fbb25c9beddd062a8f843573dff627dbe4634764e73dd525f35"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5deda5e1d566e09a0120aa92e95a59db0aeea4735da2b39147dba108b090ad"
+checksum = "110c678066e21c1694ff72ae5733feda4c03dbfc070d5ab02d908236a7c58214"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75722c380ee445a647d813125fa8432626c9f34c0729103334d591d5d94512f"
+checksum = "ebeecd1c65e719b70199e2e5b59011117647c919eee9bb8580aa7ad0ce5f1f5f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5fc7dde7ec31ad28bcdd42a813423974f0b3844faae0e5203dafd237694782"
+checksum = "7a4dab0bfd091f637a910c96c2e10a240b94256cccec688f10cf86620f1b2124"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "17.0.0"
+version = "18.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/lambdaclass/rex"
@@ -32,13 +32,13 @@ manual_saturating_arithmetic = "warn"
 rex-cli = { path = "cli" }
 rex-sdk = { path = "sdk" }
 
-ethrex-common = "17.0.0"
-ethrex-blockchain = "17.0.0"
-ethrex-rlp = "17.0.0"
-ethrex-rpc = "17.0.0"
-ethrex-l2-rpc = "17.0.0"
-ethrex-sdk = "17.0.0"
-ethrex-l2-common = "17.0.0"
+ethrex-common = "18.0.0"
+ethrex-blockchain = "18.0.0"
+ethrex-rlp = "18.0.0"
+ethrex-rpc = "18.0.0"
+ethrex-l2-rpc = "18.0.0"
+ethrex-sdk = "18.0.0"
+ethrex-l2-common = "18.0.0"
 
 keccak-hash = "0.11.0"
 thiserror = "2.0.11"


### PR DESCRIPTION
**Motivation**

rex releases must stay paired with ethrex releases. This bumps rex to v18.0.0, paired with ethrex v18.0.0 (part of the v17→v21 catch-up).

**Description**

- Bump the 7 ethrex crates.io dependencies from `17.0.0` to `18.0.0` (and regenerate `Cargo.lock`).
- Bump the ethrex binary used by the CI integration tests to v18.0.0.
- Bump the workspace version to 18.0.0 for the upcoming v18.0.0 release.
- No breaking changes affect rex's API surface (verified: `cargo check --workspace`, tests, clippy, and fmt all pass against ethrex 18.0.0); no code changes needed.