### PR TITLE
chore(cli,sdk): bump ethrex version to v20.0.0

### DIFF
--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v18.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v19.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v18.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v19.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"

--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v19.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v20.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v19.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v20.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f425381a3b5d1e4e7a9cfdddfcc14d62f70a9d5caffb8589e73851374840f366"
+checksum = "e2d1fb2ef8cd3776527104b58fc1c952fa9bd7b2dd88ffcaf89fd866c67f1414"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0221ee5723272ab439785ee1eebf43b960db7d81c438bc8bd2a8be8f801d4dae"
+checksum = "afbbfb01ebd779f1710084595deafdf2c3a352eb6b3357854127018a8a3ee26d"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38bf0a1fb41edea3fc79c551aea0d161d715505afdc76284e2101f50e99c4ee"
+checksum = "686f9f32b0126c0f44dafdf25d758e529f302662dce97f16b7adcc597ddb7374"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e274b0c18a40b82a4d491bcf22eece971026a44c894a9e9cb565ecaed02072c3"
+checksum = "14812ef9d9254259d92dea1a878a6ba306f9590423e82c18b5b892eedae344f8"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1002c33e1a8bbed4a0c233d25fe17a28e697184da22e53976a71112d36397012"
+checksum = "455b3a6200350d95ca0a33ecb7008ead543aed97c0326286f24598a902c55d35"
 dependencies = [
  "axum",
  "bytes",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f647014431f627624ed69433b545df62af66c06b961630c333a00cf4341dcf5"
+checksum = "496faa768febce8cbdbcd59528708e98cad71df60149a4b7ec85019d449ca541"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664e28bd0fd4a53b1aefe525f238899cc784c74e5f8462723c8662af2995580"
+checksum = "d229c4ea9c28e530d99e37ceefc35dda7be1a923432eb3af71677f8484fc971c"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5ea4f3aaea9129254e1c19506c4571c8a4ac1d9cd199b140d87b318abd8795"
+checksum = "2959233a81a936a1a3bcab73c6f9fdcc7b4f88e1ae90a9f1dda2573b0e1e7738"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3899a67433164d3954baeb123bcbedcb5229d9cb5a09f949a264e367ed61d55"
+checksum = "47519e5354aa491a562a5332b076257385de18ef78dddbed7bb71c1ff21215cd"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4b370d218f7fb24be540a1f8fe3dd50d629cecbe75b899bd4d66d64f0fe19c"
+checksum = "e5adf3b2d184966d83723a1035c826b97b0f62514bcfd8c9eeb341c2161daf20"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069b37b915a1a2f1f3afc4e516d3120cfd69e7ae11bf41b2a1e2d72de0a71cb5"
+checksum = "a4abc002135dcb3da38ad053a42774dd1ba60038885fafed1baa087148df4bda"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c32b6b6050fde3855cf616f4ac271754456f4f3359e480186b1c95901b60a8e"
+checksum = "509585aa28393b68702051fcfaf0e7b455891d23ab534396d0a8641954941536"
 dependencies = [
  "thiserror 2.0.17",
  "tracing",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfea8e7d6c94fbb25c9beddd062a8f843573dff627dbe4634764e73dd525f35"
+checksum = "6b31b84f98f554a2de2db9d9dbb5ae8b55c2eed4a9b9f30f0c0bfffa4fb6a2e2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110c678066e21c1694ff72ae5733feda4c03dbfc070d5ab02d908236a7c58214"
+checksum = "421dfe7684da9242ca7a3ac5c01aac5e6b034e78cac76dd7990d6c0d61e329cf"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeecd1c65e719b70199e2e5b59011117647c919eee9bb8580aa7ad0ce5f1f5f"
+checksum = "89a743ed1c7500e476dea9c0d6efb388e2063c154d95fb1ea278067b2ae2bd07"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4dab0bfd091f637a910c96c2e10a240b94256cccec688f10cf86620f1b2124"
+checksum = "23a9f2bb91d5f4401f2555a271bec01afa1d7dc512370913cecdac25f292bc9a"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "18.0.0"
+version = "19.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d1fb2ef8cd3776527104b58fc1c952fa9bd7b2dd88ffcaf89fd866c67f1414"
+checksum = "51b18c0aa23f2228f785143fe559e4315f725d20e8030d6b2508b204cbeb7e44"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbbfb01ebd779f1710084595deafdf2c3a352eb6b3357854127018a8a3ee26d"
+checksum = "d32b623b0a7f2da129dab68cb396ac97849b46ee1f6c5085e1b4dbed6d30e2f3"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f9f32b0126c0f44dafdf25d758e529f302662dce97f16b7adcc597ddb7374"
+checksum = "565131c0750cab8403928c119d89f0efd9914e2966c4cdf725416e8367160ba4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14812ef9d9254259d92dea1a878a6ba306f9590423e82c18b5b892eedae344f8"
+checksum = "7d8c2deb2bb69a888aedec089fba2302dc7956db061adaa578dd3e2df68e3111"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455b3a6200350d95ca0a33ecb7008ead543aed97c0326286f24598a902c55d35"
+checksum = "ef66d955f89de1d862e6636382b3b0ee0155263b8c61965b19e47f498584437f"
 dependencies = [
  "axum",
  "bytes",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496faa768febce8cbdbcd59528708e98cad71df60149a4b7ec85019d449ca541"
+checksum = "d1204ae29789e7add4f12d7d1dad2df98cef0c572a13760a4afc36aab8d2ac19"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d229c4ea9c28e530d99e37ceefc35dda7be1a923432eb3af71677f8484fc971c"
+checksum = "78673f2bdbd0067e1679a4dfcabd27eefd653bde71e1c01da7fa71be766ee061"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2959233a81a936a1a3bcab73c6f9fdcc7b4f88e1ae90a9f1dda2573b0e1e7738"
+checksum = "f50bccad9609b0a74bc86b4916dd7d53a04ca1f083d7c81edaaf17565f532b8f"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47519e5354aa491a562a5332b076257385de18ef78dddbed7bb71c1ff21215cd"
+checksum = "3e7e1ad74ead1fa4008c28f9dcd8f9c481b68fdc5fb5b47aa270a5582ceb4c2b"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5adf3b2d184966d83723a1035c826b97b0f62514bcfd8c9eeb341c2161daf20"
+checksum = "59cf7042f9692b96fa29349d132e02df5d16e7c26dc040ccf2544b46e88d34e6"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4abc002135dcb3da38ad053a42774dd1ba60038885fafed1baa087148df4bda"
+checksum = "71e1ef085f3690d566c5be34d08786444f4fa0bf52e650b4aaf443d02d4bc01f"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509585aa28393b68702051fcfaf0e7b455891d23ab534396d0a8641954941536"
+checksum = "bef03291cf7db5a1db2d04d39f088c97f479c35ca5d7bc7b96deafa81f010aae"
 dependencies = [
  "thiserror 2.0.17",
  "tracing",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b31b84f98f554a2de2db9d9dbb5ae8b55c2eed4a9b9f30f0c0bfffa4fb6a2e2"
+checksum = "0f933a79ac33756c2f94648e1889835174f862681f1336ae1530e4d605063105"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421dfe7684da9242ca7a3ac5c01aac5e6b034e78cac76dd7990d6c0d61e329cf"
+checksum = "af82ea1064ae76131cc45eaaa6412f219a7c3c5ac68f29f8fa0ea7dc735f179f"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a743ed1c7500e476dea9c0d6efb388e2063c154d95fb1ea278067b2ae2bd07"
+checksum = "9d2d88adef06d631bc0f282ccab0d6f765a0f7fa17988cd372a2d110fe4209c5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a9f2bb91d5f4401f2555a271bec01afa1d7dc512370913cecdac25f292bc9a"
+checksum = "bbb8c1828fbb0a19cdc2f47520a71b8b792e653a7039c320743c127b2a227d75"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "18.0.0"
+version = "19.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/lambdaclass/rex"
@@ -32,13 +32,13 @@ manual_saturating_arithmetic = "warn"
 rex-cli = { path = "cli" }
 rex-sdk = { path = "sdk" }
 
-ethrex-common = "18.0.0"
-ethrex-blockchain = "18.0.0"
-ethrex-rlp = "18.0.0"
-ethrex-rpc = "18.0.0"
-ethrex-l2-rpc = "18.0.0"
-ethrex-sdk = "18.0.0"
-ethrex-l2-common = "18.0.0"
+ethrex-common = "19.0.0"
+ethrex-blockchain = "19.0.0"
+ethrex-rlp = "19.0.0"
+ethrex-rpc = "19.0.0"
+ethrex-l2-rpc = "19.0.0"
+ethrex-sdk = "19.0.0"
+ethrex-l2-common = "19.0.0"
 
 keccak-hash = "0.11.0"
 thiserror = "2.0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "19.0.0"
+version = "20.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/lambdaclass/rex"
@@ -32,13 +32,13 @@ manual_saturating_arithmetic = "warn"
 rex-cli = { path = "cli" }
 rex-sdk = { path = "sdk" }
 
-ethrex-common = "19.0.0"
-ethrex-blockchain = "19.0.0"
-ethrex-rlp = "19.0.0"
-ethrex-rpc = "19.0.0"
-ethrex-l2-rpc = "19.0.0"
-ethrex-sdk = "19.0.0"
-ethrex-l2-common = "19.0.0"
+ethrex-common = "20.0.0"
+ethrex-blockchain = "20.0.0"
+ethrex-rlp = "20.0.0"
+ethrex-rpc = "20.0.0"
+ethrex-l2-rpc = "20.0.0"
+ethrex-sdk = "20.0.0"
+ethrex-l2-common = "20.0.0"
 
 keccak-hash = "0.11.0"
 thiserror = "2.0.11"


### PR DESCRIPTION
**Motivation**

rex releases must stay paired with ethrex releases. This bumps rex to v20.0.0, paired with ethrex v20.0.0 (part of the v17→v21 catch-up).

> Stacked on #242 (v19). Once #242 merges, GitHub retargets this to `main` and I'll rebase so the diff stays v19→v20 only.

**Description**

- Bump the 7 ethrex crates.io dependencies from `19.0.0` to `20.0.0` (and regenerate `Cargo.lock`).
- Bump the ethrex binary used by the CI integration tests to v20.0.0.
- Bump the workspace version to 20.0.0 for the upcoming v20.0.0 release.
- No breaking changes affect rex's API surface (verified: `cargo check --workspace`, tests, clippy, and fmt all pass against ethrex 20.0.0); no code changes needed.