### PR TITLE
feat(cli): EIP-8141 frame transaction support + bump ethrex to v21.0.0

### DIFF
--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v20.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v21.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install ethrex
         run: |
-          curl -L https://github.com/lambdaclass/ethrex/releases/download/v20.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
+          curl -L https://github.com/lambdaclass/ethrex/releases/download/v21.0.0/ethrex-l2-linux-x86_64 -o /usr/local/bin/ethrex
           chmod +x /usr/local/bin/ethrex
           ethrex --version
           echo "ethrex installed successfully"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b18c0aa23f2228f785143fe559e4315f725d20e8030d6b2508b204cbeb7e44"
+checksum = "3624fc7d55b0c40b619f010dde1eb40488158824e2b4d20b1d27c66b75205b28"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32b623b0a7f2da129dab68cb396ac97849b46ee1f6c5085e1b4dbed6d30e2f3"
+checksum = "963f0adf9e7d9d3bf64f548f4f890e5597f1004bbc1a51d4f0fd5d2e2c847db9"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565131c0750cab8403928c119d89f0efd9914e2966c4cdf725416e8367160ba4"
+checksum = "bacbe9c76ea2bf435ed0a5eed794119eb24bc5f32b440ed3c6671deb95ff3beb"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8c2deb2bb69a888aedec089fba2302dc7956db061adaa578dd3e2df68e3111"
+checksum = "362db51e8a6a2cc85e597df89c55a885969ac0350888b76065c5152037837799"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef66d955f89de1d862e6636382b3b0ee0155263b8c61965b19e47f498584437f"
+checksum = "64e7cb55694842834b1901a6fecf715a097c626c232de31f2baeb71e85338fc8"
 dependencies = [
  "axum",
  "bytes",
@@ -1362,6 +1362,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1370,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1204ae29789e7add4f12d7d1dad2df98cef0c572a13760a4afc36aab8d2ac19"
+checksum = "57099a027ec7d0de25c2d59803f758f23f34d0bc5288497a56457cd64f694569"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1389,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78673f2bdbd0067e1679a4dfcabd27eefd653bde71e1c01da7fa71be766ee061"
+checksum = "f80fd7a9a151c11e2e51ad4ea66d8d93da6239229c592145c986935873434d09"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1406,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50bccad9609b0a74bc86b4916dd7d53a04ca1f083d7c81edaaf17565f532b8f"
+checksum = "c3754cc5d43fab263e81fbeba0265742cb5dfd601426a90f23815fefed8da836"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1451,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e1ad74ead1fa4008c28f9dcd8f9c481b68fdc5fb5b47aa270a5582ceb4c2b"
+checksum = "32b0be92a36ab5a64a697e78c62fa85f2ef42aee3e699b6ce4cbf40a6b12d2bd"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1462,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cf7042f9692b96fa29349d132e02df5d16e7c26dc040ccf2544b46e88d34e6"
+checksum = "48917b4419d99558327b4d5c60b2d768edbd7e32f90427f8c36f97cbe1ba3f0b"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1503,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e1ef085f3690d566c5be34d08786444f4fa0bf52e650b4aaf443d02d4bc01f"
+checksum = "20a7b715c8fb2bd0abf36800f3a1b82786034f7707b9acb3156b5774d9201653"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1529,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef03291cf7db5a1db2d04d39f088c97f479c35ca5d7bc7b96deafa81f010aae"
+checksum = "3a591545e7badcd07d7294a95b3dcef6e8583d606b6b0a61e05e2450e7e0408d"
 dependencies = [
  "thiserror 2.0.17",
  "tracing",
@@ -1539,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f933a79ac33756c2f94648e1889835174f862681f1336ae1530e4d605063105"
+checksum = "df6340a4a686b633d1402d31481e7c8ac871e431e35c2a8dd3ee8655a827cb5d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1562,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af82ea1064ae76131cc45eaaa6412f219a7c3c5ac68f29f8fa0ea7dc735f179f"
+checksum = "65f5476bffb3a6babdd913d21549a7d198de1bb35ca985595c41018eebc7b401"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1579,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2d88adef06d631bc0f282ccab0d6f765a0f7fa17988cd372a2d110fe4209c5"
+checksum = "519727e4ebd9e792235bbf2cd82b67b6af95910e630d23e074a7f8280b3b51a7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1599,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb8c1828fbb0a19cdc2f47520a71b8b792e653a7039c320743c127b2a227d75"
+checksum = "80b2b4518041f6929f6596a98a8b7870a23cad3f95e1f865554acfb2166ad6f7"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3343,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "20.0.0"
+version = "21.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3378,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "20.0.0"
+version = "21.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "20.0.0"
+version = "21.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/lambdaclass/rex"
@@ -32,13 +32,13 @@ manual_saturating_arithmetic = "warn"
 rex-cli = { path = "cli" }
 rex-sdk = { path = "sdk" }
 
-ethrex-common = "20.0.0"
-ethrex-blockchain = "20.0.0"
-ethrex-rlp = "20.0.0"
-ethrex-rpc = "20.0.0"
-ethrex-l2-rpc = "20.0.0"
-ethrex-sdk = "20.0.0"
-ethrex-l2-common = "20.0.0"
+ethrex-common = "21.0.0"
+ethrex-blockchain = "21.0.0"
+ethrex-rlp = "21.0.0"
+ethrex-rpc = "21.0.0"
+ethrex-l2-rpc = "21.0.0"
+ethrex-sdk = "21.0.0"
+ethrex-l2-common = "21.0.0"
 
 keccak-hash = "0.11.0"
 thiserror = "2.0.11"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Commands:
   create-address    Compute contract address given the deployer address and nonce.
   create2-address   Compute contract address for CREATE2 deployments.
   deploy            Deploy a contract
+  frame             Send, build, or inspect an EIP-8141 frame transaction (tx type 0x06)
   hash              Get either the keccak for a given input, the zero hash, the empty string, or a random hash [aliases: h, keccak]
   l2                L2 specific commands.
   nonce             Get the account's nonce. [aliases: n]

--- a/cli/src/commands/frame.rs
+++ b/cli/src/commands/frame.rs
@@ -1,24 +1,28 @@
 //! EIP-8141 frame transaction support (tx type 0x06).
 //!
-//! The frame-tx envelope is `0x06 || rlp(chain_id, nonce, sender, frames,
-//! max_priority_fee, max_fee, max_blob_fee, blob_hashes)` where each frame is
-//! `rlp(mode, flags, target, gas_limit, data)` (5 fields).
+//! This uses ethrex's canonical `FrameTransaction` types directly (via the
+//! `ethrex-common` dependency pinned to 21.0.0) so the wire format, `sig_hash`,
+//! and RLP encoding stay in lockstep with the deployed chain and cannot drift
+//! out of the spec.
 //!
-//! - `mode`:  execution mode (1 = VERIFY, 2 = SENDER)
-//! - `flags`: bitmask — 0x01 = PAYMENT approval, 0x02 = EXECUTION approval,
-//!   0x03 = both, 0x04 = atomic batch
+//! Envelope: `0x06 || rlp([chain_id, nonce, sender, frames, signatures,
+//! max_priority_fee, max_fee, max_fee_per_blob_gas, blob_versioned_hashes])`
+//!   - frame     = `rlp([mode, flags, target, gas_limit, value, data])`
+//!   - signature = `rlp([scheme, signer, msg, signature_bytes])`
+//!   - sig_hash  = `keccak(0x06 || rlp(envelope with empty-msg signature bytes elided))`
 //!
-//! sig_hash = keccak(0x06 || rlp(...)) with VERIFY frame data replaced by
-//! empty bytes so the signature signs over the frame structure but not over
-//! itself. Default EOA VERIFY data is `[0x00 (type), v, r, s]` = 66 bytes.
+//! - `mode`:  0 = DEFAULT, 1 = VERIFY, 2 = SENDER (3-255 reserved)
+//! - `flags`: bit 0 = PAYMENT approval, bit 1 = EXECUTION approval, bit 2 = atomic batch
+//! - a secp256k1 outer signature is `v(1) || r(32) || s(32)`, v = recovery_id + 27
 
 use clap::Subcommand;
+use ethrex_common::types::{
+    FRAME_SIG_SCHEME_SECP256K1, Frame, FrameSignature, FrameTransaction, Transaction,
+};
 use ethrex_common::{Address, Bytes, H256, U256};
 use ethrex_l2_common::utils::get_address_from_secret_key;
-use ethrex_rlp::structs::Encoder;
 use ethrex_rpc::EthClient;
 use ethrex_rpc::utils::{RpcRequest, RpcResponse};
-use keccak_hash::keccak;
 use rex_sdk::sign::sign_hash;
 use secp256k1::SecretKey;
 use serde::Deserialize;
@@ -27,148 +31,80 @@ use url::Url;
 
 use crate::utils::{parse_hex, parse_private_key};
 
-pub const EXEC_MODE_VERIFY: u8 = 1;
-pub const EXEC_MODE_SENDER: u8 = 2;
+pub const MODE_DEFAULT: u8 = 0;
+pub const MODE_VERIFY: u8 = 1;
+pub const MODE_SENDER: u8 = 2;
 
-/// Flag bitmasks (post spec-update: 0x01=PAYMENT, 0x02=EXECUTION).
+/// Flag bitmasks (0x01 = PAYMENT, 0x02 = EXECUTION, 0x04 = atomic batch).
 pub const FLAG_PAYMENT: u8 = 0x01;
 pub const FLAG_EXECUTION: u8 = 0x02;
 pub const FLAG_BOTH: u8 = 0x03;
-#[allow(dead_code)] // defined for future atomic batch support
 pub const FLAG_ATOMIC_BATCH: u8 = 0x04;
 
-#[derive(Debug, Clone)]
-pub struct Frame {
-    pub mode: u8,
-    pub flags: u8,
-    pub target: Address,
-    pub gas_limit: u64,
-    pub data: Bytes,
-}
-
-impl Frame {
-    pub fn is_verify(&self) -> bool {
-        self.mode == EXEC_MODE_VERIFY
+fn mode_name(mode: u8) -> &'static str {
+    match mode {
+        MODE_DEFAULT => "DEFAULT",
+        MODE_VERIFY => "VERIFY",
+        MODE_SENDER => "SENDER",
+        _ => "RESERVED",
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct FrameTx {
-    pub chain_id: u64,
-    pub nonce: u64,
-    pub sender: Address,
-    pub frames: Vec<Frame>,
-    pub max_priority_fee_per_gas: U256,
-    pub max_fee_per_gas: U256,
-    pub max_fee_per_blob_gas: U256,
-    pub blob_versioned_hashes: Vec<H256>,
-}
-
-fn encode_frame_bytes(frame: &Frame, elide_data: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    let data: &[u8] = if elide_data { &[] } else { frame.data.as_ref() };
-    Encoder::new(&mut out)
-        .encode_field(&(frame.mode as u64))
-        .encode_field(&(frame.flags as u64))
-        .encode_field(&frame.target)
-        .encode_field(&frame.gas_limit)
-        .encode_bytes(data)
-        .finish();
-    out
-}
-
-fn encode_frames_list(frames: &[Frame], elide_verify_data: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    let mut enc = Encoder::new(&mut out);
-    for frame in frames {
-        let single = encode_frame_bytes(frame, elide_verify_data && frame.is_verify());
-        enc = enc.encode_raw(&single);
-    }
-    enc.finish();
-    out
-}
-
-impl FrameTx {
-    fn encode_payload(&self, elide_verify_data: bool) -> Vec<u8> {
-        let frames_rlp = encode_frames_list(&self.frames, elide_verify_data);
-        let mut payload = Vec::new();
-        Encoder::new(&mut payload)
-            .encode_field(&self.chain_id)
-            .encode_field(&self.nonce)
-            .encode_field(&self.sender)
-            .encode_raw(&frames_rlp)
-            .encode_field(&self.max_priority_fee_per_gas)
-            .encode_field(&self.max_fee_per_gas)
-            .encode_field(&self.max_fee_per_blob_gas)
-            .encode_field(&self.blob_versioned_hashes)
-            .finish();
-        payload
-    }
-
-    pub fn sig_hash(&self) -> H256 {
-        let payload = self.encode_payload(true);
-        let mut buf = Vec::with_capacity(payload.len() + 1);
-        buf.push(0x06);
-        buf.extend_from_slice(&payload);
-        keccak(&buf)
-    }
-
-    pub fn to_raw(&self) -> Vec<u8> {
-        let payload = self.encode_payload(false);
-        let mut out = Vec::with_capacity(payload.len() + 1);
-        out.push(0x06);
-        out.extend_from_slice(&payload);
-        out
+/// Human-readable flag decode: APPROVE scope + atomic-batch bit.
+fn flags_desc(flags: u8) -> String {
+    let scope = match flags & 0x03 {
+        0x00 => "APPROVE none",
+        FLAG_PAYMENT => "APPROVE payment",
+        FLAG_EXECUTION => "APPROVE execution",
+        FLAG_BOTH => "APPROVE execution+payment",
+        _ => unreachable!(),
+    };
+    if flags & FLAG_ATOMIC_BATCH != 0 {
+        format!("{scope}, atomic-batch")
+    } else {
+        scope.to_string()
     }
 }
 
-/// Sign the sig_hash with secp256k1 and return the 66-byte default EOA VERIFY
-/// data: `[0x00 (secp256k1 type), v, r, s]`.
-pub fn default_eoa_verify_data(sig_hash: H256, secret: &SecretKey) -> Vec<u8> {
-    // sign_hash returns [r(32), s(32), v(1, already +27)] = 65 bytes.
+/// A secp256k1 outer signature over `sig_hash`, encoded as ethrex expects
+/// (`v || r || s`, v = recovery_id + 27). `msg` is empty, so its signature bytes
+/// are elided from the sig_hash; `signer` is the account whose key signed.
+fn secp256k1_signature(sig_hash: H256, signer: Address, secret: &SecretKey) -> FrameSignature {
+    // sign_hash returns r(32) || s(32) || v(1, already +27).
     let sig = sign_hash(sig_hash, *secret);
-    debug_assert_eq!(sig.len(), 65);
-    let r = &sig[0..32];
-    let s = &sig[32..64];
-    let v = sig[64];
-    let mut out = Vec::with_capacity(66);
-    out.push(0x00);
-    out.push(v);
-    out.extend_from_slice(r);
-    out.extend_from_slice(s);
-    out
-}
-
-/// Sign the sig_hash with the paymaster owner key and return the 65-byte
-/// CanonicalPaymaster VERIFY data: `r(32) || s(32) || v(1)`. No leading
-/// type byte — the paymaster contract expects exactly these 65 bytes.
-pub fn paymaster_owner_verify_data(sig_hash: H256, owner_secret: &SecretKey) -> Vec<u8> {
-    // sign_hash already returns r||s||v = 65 bytes with v = recovery_id + 27.
-    let sig = sign_hash(sig_hash, *owner_secret);
-    debug_assert_eq!(sig.len(), 65);
-    sig
-}
-
-/// Default SENDER frame data: `rlp([[target, value, calldata], ...])`.
-pub fn encode_sender_calls(calls: &[(Address, U256, Bytes)]) -> Vec<u8> {
-    let mut out = Vec::new();
-    let mut outer = Encoder::new(&mut out);
-    for (target, value, data) in calls {
-        let mut call_buf = Vec::new();
-        Encoder::new(&mut call_buf)
-            .encode_field(target)
-            .encode_field(value)
-            .encode_bytes(data)
-            .finish();
-        outer = outer.encode_raw(&call_buf);
+    let mut bytes = Vec::with_capacity(65);
+    bytes.push(sig[64]); // v
+    bytes.extend_from_slice(&sig[0..32]); // r
+    bytes.extend_from_slice(&sig[32..64]); // s
+    FrameSignature {
+        scheme: FRAME_SIG_SCHEME_SECP256K1,
+        signer,
+        msg: Bytes::new(),
+        signature: Bytes::from(bytes),
     }
-    outer.finish();
-    out
 }
 
-/// Parse an amount like `1ether`, `1.5gwei`, `100mwei`, `500wei`, or a plain
-/// wei integer. Duplicated here so this branch stays independent of the
-/// ether-units branch.
+/// An empty-bytes signature placeholder: fixes the signatures-list length,
+/// scheme, signer and (empty) msg so `compute_sig_hash` sees the final structure.
+/// The empty bytes are elided from the hash and filled in after signing.
+fn signature_placeholder(signer: Address) -> FrameSignature {
+    FrameSignature {
+        scheme: FRAME_SIG_SCHEME_SECP256K1,
+        signer,
+        msg: Bytes::new(),
+        signature: Bytes::new(),
+    }
+}
+
+fn raw_canonical(tx: FrameTransaction) -> Vec<u8> {
+    Transaction::FrameTransaction(tx).encode_canonical_to_vec()
+}
+
+fn u256_to_u64(v: U256, field: &str) -> eyre::Result<u64> {
+    u64::try_from(v).map_err(|_| eyre::eyre!("{field} does not fit in u64: {v}"))
+}
+
+/// Parse a "1ether"/"1.5gwei"/"0x…"/plain-wei amount into a wei `U256`.
 fn parse_amount(s: &str) -> eyre::Result<U256> {
     const UNITS: &[(&str, u32)] = &[
         ("ether", 18),
@@ -241,7 +177,7 @@ fn parse_amount(s: &str) -> eyre::Result<U256> {
 pub(crate) enum Command {
     #[clap(about = "Send a frame (EIP-8141, tx type 0x06) transaction.")]
     Send {
-        #[arg(long, help = "Recipient of the inner SENDER call.")]
+        #[arg(long, help = "Recipient of the SENDER frame.")]
         to: Address,
         #[arg(
             long,
@@ -254,17 +190,19 @@ pub(crate) enum Command {
             long,
             default_value = "",
             value_parser = parse_hex,
-            help = "Calldata for the inner subcall. Empty for plain ETH transfer."
+            help = "Calldata for the SENDER frame. Empty for plain ETH transfer."
         )]
         data: Bytes,
-        #[arg(long, help = "Optional gas-sponsor address for a sponsored tx.")]
+        #[arg(
+            long,
+            help = "Optional gas-sponsor (paymaster) address for a sponsored tx."
+        )]
         sponsor: Option<Address>,
         #[arg(
             long,
             default_value = "",
             value_parser = parse_hex,
             requires = "sponsor",
-            conflicts_with = "sponsor_owner_key",
             help = "Static calldata passed to the sponsor's VERIFY frame (e.g. 0xfc735e99 for GasSponsor)."
         )]
         sponsor_calldata: Bytes,
@@ -273,7 +211,7 @@ pub(crate) enum Command {
             value_parser = parse_private_key,
             requires = "sponsor",
             env = "SPONSOR_OWNER_KEY",
-            help = "Private key that owns the sponsor contract (e.g. CanonicalPaymaster). When set, the sponsor VERIFY frame data is r(32)||s(32)||v(1) = 65 bytes, signed by this key over the sig_hash."
+            help = "Private key that owns the sponsor contract. When set, a second outer signature (signer = the owner) is added to the signatures list."
         )]
         sponsor_owner_key: Option<SecretKey>,
         #[arg(long, default_value_t = 100_000)]
@@ -299,8 +237,9 @@ pub(crate) enum Command {
     #[clap(
         about = "Build a raw frame tx from explicit frames (no RPC calls).",
         long_about = "Build a frame tx envelope from explicit parameters. --frames is a JSON \
-                      array of {mode, target, gasLimit, data} objects. Useful when you want \
-                      to inspect the raw 0x06 bytes before sending."
+                      array of {mode, flags, target, gasLimit, value, data} objects. The \
+                      envelope is left unsigned (empty signatures list); useful for inspecting \
+                      the raw 0x06 bytes before sending."
     )]
     Build {
         #[arg(long)]
@@ -311,7 +250,7 @@ pub(crate) enum Command {
         sender: Address,
         #[arg(
             long,
-            help = "JSON array of frames, e.g. '[{\"mode\":769,\"target\":\"0x…\",\"gasLimit\":100000,\"data\":\"0x\"}]'."
+            help = "JSON array of frames, e.g. '[{\"mode\":1,\"flags\":3,\"target\":\"0x…\",\"gasLimit\":100000,\"value\":\"0\",\"data\":\"0x\"}]'."
         )]
         frames: String,
         #[arg(long, default_value = "10gwei", value_parser = parse_amount)]
@@ -319,8 +258,11 @@ pub(crate) enum Command {
         #[arg(long, default_value = "1gwei", value_parser = parse_amount)]
         max_priority_fee: U256,
     },
-    #[clap(about = "Display a frame-tx receipt including payer and per-frame status.")]
-    Receipt {
+    #[clap(
+        about = "Inspect a frame tx: decode its frames and pair them with their per-frame results.",
+        alias = "receipt"
+    )]
+    Inspect {
         tx_hash: H256,
         #[arg(long, default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: Url,
@@ -332,9 +274,12 @@ struct FrameJson {
     mode: u8,
     #[serde(default)]
     flags: u8,
-    target: Address,
+    #[serde(default)]
+    target: Option<Address>,
     #[serde(alias = "gasLimit", alias = "gas_limit")]
     gas_limit: u64,
+    #[serde(default)]
+    value: Option<String>,
     #[serde(default)]
     data: String,
 }
@@ -379,78 +324,102 @@ impl Command {
                     }
                 };
 
-                let sender_data = encode_sender_calls(&[(to, value, data)]);
-
-                let mut frames = if let Some(sponsor_addr) = sponsor {
-                    vec![
-                        Frame {
-                            mode: EXEC_MODE_VERIFY,
-                            flags: FLAG_EXECUTION,
-                            target: sender,
-                            gas_limit: frame_gas_limit,
-                            data: Bytes::new(),
-                        },
-                        Frame {
-                            mode: EXEC_MODE_VERIFY,
-                            flags: FLAG_PAYMENT,
-                            target: sponsor_addr,
-                            gas_limit: sponsor_gas_limit,
-                            data: sponsor_calldata,
-                        },
-                        Frame {
-                            mode: EXEC_MODE_SENDER,
-                            flags: 0,
-                            target: sender,
-                            gas_limit: frame_gas_limit,
-                            data: sender_data.into(),
-                        },
-                    ]
+                // Build the frames. SENDER frames carry their value/data directly
+                // (per-frame `value`), not an encoded call list in `data`.
+                let (frames, mut signatures) = if let Some(sponsor_addr) = sponsor {
+                    let owner = match &sponsor_owner_key {
+                        Some(k) => get_address_from_secret_key(&k.secret_bytes())
+                            .map_err(|e| eyre::eyre!(e))?,
+                        None => sponsor_addr,
+                    };
+                    (
+                        vec![
+                            Frame {
+                                mode: MODE_VERIFY,
+                                flags: FLAG_EXECUTION,
+                                target: Some(sender),
+                                gas_limit: frame_gas_limit,
+                                value: U256::zero(),
+                                data: Bytes::new(),
+                            },
+                            Frame {
+                                mode: MODE_VERIFY,
+                                flags: FLAG_PAYMENT,
+                                target: Some(sponsor_addr),
+                                gas_limit: sponsor_gas_limit,
+                                value: U256::zero(),
+                                data: sponsor_calldata,
+                            },
+                            Frame {
+                                mode: MODE_SENDER,
+                                flags: 0,
+                                target: Some(to),
+                                gas_limit: frame_gas_limit,
+                                value,
+                                data,
+                            },
+                        ],
+                        // sender approves execution; owner (or sponsor) approves payment.
+                        vec![signature_placeholder(sender), signature_placeholder(owner)],
+                    )
                 } else {
-                    vec![
-                        Frame {
-                            mode: EXEC_MODE_VERIFY,
-                            flags: FLAG_BOTH,
-                            target: sender,
-                            gas_limit: frame_gas_limit,
-                            data: Bytes::new(),
-                        },
-                        Frame {
-                            mode: EXEC_MODE_SENDER,
-                            flags: 0,
-                            target: sender,
-                            gas_limit: frame_gas_limit,
-                            data: sender_data.into(),
-                        },
-                    ]
+                    (
+                        vec![
+                            Frame {
+                                mode: MODE_VERIFY,
+                                flags: FLAG_BOTH,
+                                target: Some(sender),
+                                gas_limit: frame_gas_limit,
+                                value: U256::zero(),
+                                data: Bytes::new(),
+                            },
+                            Frame {
+                                mode: MODE_SENDER,
+                                flags: 0,
+                                target: Some(to),
+                                gas_limit: frame_gas_limit,
+                                value,
+                                data,
+                            },
+                        ],
+                        vec![signature_placeholder(sender)],
+                    )
                 };
 
                 let chain_id_u64: u64 = chain_id
                     .try_into()
                     .map_err(|_| eyre::eyre!("chain id {chain_id} does not fit in u64"))?;
 
-                let unsigned = FrameTx {
+                let mut tx = FrameTransaction {
                     chain_id: chain_id_u64,
                     nonce,
                     sender,
-                    frames: frames.clone(),
-                    max_priority_fee_per_gas,
-                    max_fee_per_gas: max_fee,
+                    frames,
+                    signatures: signatures.clone(),
+                    max_priority_fee_per_gas: u256_to_u64(
+                        max_priority_fee_per_gas,
+                        "max_priority_fee_per_gas",
+                    )?,
+                    max_fee_per_gas: u256_to_u64(max_fee, "max_fee_per_gas")?,
                     max_fee_per_blob_gas: U256::zero(),
                     blob_versioned_hashes: Vec::new(),
+                    ..Default::default()
                 };
 
-                let sig_hash = unsigned.sig_hash();
-                let verify_data = default_eoa_verify_data(sig_hash, &private_key);
-                frames[0].data = verify_data.into();
-
-                if let Some(owner_key) = sponsor_owner_key {
-                    // Sponsor VERIFY is frame index 1 in the sponsored layout.
-                    // Override its data with the owner's 65-byte r||s||v signature.
-                    frames[1].data = paymaster_owner_verify_data(sig_hash, &owner_key).into();
+                // Sign the sig_hash (signatures' empty-msg bytes are elided from it),
+                // then fill the real signature bytes back in.
+                let sig_hash = tx.compute_sig_hash();
+                signatures[0] = secp256k1_signature(sig_hash, sender, &private_key);
+                if let Some(owner_key) = &sponsor_owner_key {
+                    let owner = get_address_from_secret_key(&owner_key.secret_bytes())
+                        .map_err(|e| eyre::eyre!(e))?;
+                    signatures[1] = secp256k1_signature(sig_hash, owner, owner_key);
                 }
+                // Set the real signatures before any canonical encoding runs, so
+                // the (still-empty) canonical cache is populated from the signed tx.
+                tx.signatures = signatures;
 
-                let signed_tx = FrameTx { frames, ..unsigned };
-                let raw = signed_tx.to_raw();
+                let raw = raw_canonical(tx);
 
                 if dry_run {
                     println!("sig_hash:  0x{sig_hash:x}");
@@ -461,10 +430,8 @@ impl Command {
 
                 let tx_hash = client.send_raw_transaction(&raw).await?;
                 println!("{tx_hash:#x}");
-                // Standard wait_for_transaction_receipt deserializes to the typed
-                // RpcReceipt which doesn't know about tx type 0x06, so we poll
-                // directly via raw JSON — same path as `rex frame receipt`.
-                poll_and_print_frame_receipt(&client, tx_hash, 100).await
+                // The typed RpcReceipt doesn't model tx type 0x06, so inspect via raw JSON.
+                poll_and_inspect(&client, tx_hash, 100).await
             }
             Command::Build {
                 chain_id,
@@ -481,68 +448,78 @@ impl Command {
                         Bytes::new()
                     } else {
                         let s = f.data.strip_prefix("0x").unwrap_or(&f.data);
-                        hex::decode(s)?.into()
+                        Bytes::from(hex::decode(s)?)
+                    };
+                    let value = match f.value {
+                        Some(v) => parse_amount(&v)?,
+                        None => U256::zero(),
                     };
                     out_frames.push(Frame {
                         mode: f.mode,
                         flags: f.flags,
                         target: f.target,
                         gas_limit: f.gas_limit,
+                        value,
                         data: data_bytes,
                     });
                 }
-                let tx = FrameTx {
+                let tx = FrameTransaction {
                     chain_id,
                     nonce,
                     sender,
                     frames: out_frames,
-                    max_priority_fee_per_gas: max_priority_fee,
-                    max_fee_per_gas: max_fee,
+                    signatures: Vec::new(),
+                    max_priority_fee_per_gas: u256_to_u64(max_priority_fee, "max_priority_fee")?,
+                    max_fee_per_gas: u256_to_u64(max_fee, "max_fee")?,
                     max_fee_per_blob_gas: U256::zero(),
                     blob_versioned_hashes: Vec::new(),
+                    ..Default::default()
                 };
-                println!("0x{}", hex::encode(tx.to_raw()));
+                println!("0x{}", hex::encode(raw_canonical(tx)));
                 Ok(())
             }
-            Command::Receipt { tx_hash, rpc_url } => {
+            Command::Inspect { tx_hash, rpc_url } => {
                 let client = EthClient::new(rpc_url)?;
-                fetch_and_print_frame_receipt(&client, tx_hash).await
+                inspect_frame_tx(&client, tx_hash).await
             }
         }
     }
 }
 
-async fn fetch_and_print_frame_receipt(client: &EthClient, tx_hash: H256) -> eyre::Result<()> {
-    let value = fetch_raw_receipt(client, tx_hash).await?;
-    let obj = value
-        .as_object()
-        .ok_or_else(|| eyre::eyre!("receipt not found for {tx_hash:#x}"))?;
-    print_raw_frame_receipt(obj);
-    Ok(())
-}
-
-async fn fetch_raw_receipt(client: &EthClient, tx_hash: H256) -> eyre::Result<serde_json::Value> {
+async fn send_raw_rpc(
+    client: &EthClient,
+    method: &str,
+    tx_hash: H256,
+) -> eyre::Result<serde_json::Value> {
     let request = RpcRequest::new(
-        "eth_getTransactionReceipt",
+        method,
         Some(vec![serde_json::json!(format!("0x{tx_hash:x}"))]),
     );
-    let response = client.send_request(request).await?;
-    match response {
+    match client.send_request(request).await? {
         RpcResponse::Success(s) => Ok(s.result),
         RpcResponse::Error(e) => Err(eyre::eyre!("rpc error: {}", e.error.message)),
     }
 }
 
-async fn poll_and_print_frame_receipt(
-    client: &EthClient,
-    tx_hash: H256,
-    max_retries: u64,
-) -> eyre::Result<()> {
+async fn inspect_frame_tx(client: &EthClient, tx_hash: H256) -> eyre::Result<()> {
+    let receipt = send_raw_rpc(client, "eth_getTransactionReceipt", tx_hash).await?;
+    let receipt = receipt
+        .as_object()
+        .ok_or_else(|| eyre::eyre!("receipt not found for {tx_hash:#x}"))?;
+    // The transaction carries the frames themselves (the receipt only has results).
+    let tx = send_raw_rpc(client, "eth_getTransactionByHash", tx_hash)
+        .await
+        .ok()
+        .and_then(|v| v.as_object().cloned());
+    print_frame_tx(tx.as_ref(), receipt);
+    Ok(())
+}
+
+async fn poll_and_inspect(client: &EthClient, tx_hash: H256, max_retries: u64) -> eyre::Result<()> {
     for attempt in 1..=max_retries {
-        let value = fetch_raw_receipt(client, tx_hash).await?;
-        if let Some(obj) = value.as_object() {
-            print_raw_frame_receipt(obj);
-            return Ok(());
+        let value = send_raw_rpc(client, "eth_getTransactionReceipt", tx_hash).await?;
+        if value.as_object().is_some() {
+            return inspect_frame_tx(client, tx_hash).await;
         }
         if attempt == max_retries {
             return Err(eyre::eyre!(
@@ -555,51 +532,115 @@ async fn poll_and_print_frame_receipt(
     Ok(())
 }
 
-fn print_raw_frame_receipt(receipt: &serde_json::Map<String, serde_json::Value>) {
-    let status_str = receipt
-        .get("status")
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-    let status = match status_str {
+fn s<'a>(obj: &'a serde_json::Map<String, serde_json::Value>, key: &str) -> &'a str {
+    obj.get(key).and_then(|v| v.as_str()).unwrap_or("?")
+}
+
+/// Print a unified, decoded view: header (sender/payer/nonce/fees) + a
+/// frame-by-frame listing pairing each frame (mode, flags, target, value, data)
+/// with its result (status, gas, #logs). Works with just the receipt when the
+/// transaction body isn't available (e.g. still pending).
+fn print_frame_tx(
+    tx: Option<&serde_json::Map<String, serde_json::Value>>,
+    receipt: &serde_json::Map<String, serde_json::Value>,
+) {
+    let status = match s(receipt, "status") {
         "0x1" => "SUCCESS",
         "0x0" => "FAILED",
         other => other,
     };
-    let block = receipt
-        .get("blockNumber")
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-    let gas_used = receipt
-        .get("gasUsed")
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-    let payer = receipt
-        .get("payer")
-        .and_then(|v| v.as_str())
-        .unwrap_or("N/A");
+    println!("Frame transaction (type 0x06)");
+    println!("  status:    {status}");
+    println!("  block:     {}", s(receipt, "blockNumber"));
+    println!("  gas used:  {}", s(receipt, "gasUsed"));
 
-    println!("Status:    {status}");
-    println!("Block:     {block}");
-    println!("Gas used:  {gas_used}");
-    println!("Payer:     {payer}");
+    // The canonical FrameTransaction JSON names the account `sender`; RPC
+    // transaction objects conventionally also expose `from`.
+    let sender = tx.and_then(|t| {
+        t.get("from")
+            .or_else(|| t.get("sender"))
+            .and_then(|v| v.as_str())
+    });
+    let payer = receipt.get("payer").and_then(|v| v.as_str());
+    match (payer, sender) {
+        (Some(p), Some(f)) if p.eq_ignore_ascii_case(f) => println!("  payer:     {p} (self)"),
+        (Some(p), _) => println!("  payer:     {p}"),
+        (None, _) => println!("  payer:     N/A"),
+    }
+    if let Some(t) = tx {
+        if let Some(sender) = sender {
+            println!("  sender:    {sender}");
+        }
+        println!("  nonce:     {}", s(t, "nonce"));
+        println!(
+            "  maxFee:    {}  maxPriorityFee: {}",
+            s(t, "maxFeePerGas"),
+            s(t, "maxPriorityFeePerGas")
+        );
+        if let Some(sigs) = t.get("signatures").and_then(|v| v.as_array()) {
+            println!("  signatures: {}", sigs.len());
+        }
+    }
 
-    if let Some(frame_receipts) = receipt.get("frameReceipts").and_then(|v| v.as_array()) {
-        println!("Frames:    {}", frame_receipts.len());
-        for (i, fr) in frame_receipts.iter().enumerate() {
-            let st = fr.get("status").and_then(|v| v.as_str()).unwrap_or("?");
-            let st = match st {
-                "0x1" => "OK",
-                "0x0" => "FAIL",
+    let frames = tx.and_then(|t| t.get("frames").and_then(|v| v.as_array()));
+    let results = receipt.get("frameReceipts").and_then(|v| v.as_array());
+    let frame_count = frames.map(|f| f.len()).unwrap_or(0);
+    let result_count = results.map(|r| r.len()).unwrap_or(0);
+    let count = frame_count.max(result_count);
+
+    println!("  frames:    {count}");
+    for i in 0..count {
+        let frame = frames.and_then(|f| f.get(i)).and_then(|v| v.as_object());
+        let result = results.and_then(|r| r.get(i)).and_then(|v| v.as_object());
+
+        // Frame structure (from the tx body).
+        let header = if let Some(fr) = frame {
+            let mode = fr
+                .get("mode")
+                .and_then(|v| v.as_str())
+                .and_then(|h| u8::from_str_radix(h.trim_start_matches("0x"), 16).ok())
+                .unwrap_or(0);
+            let flags = fr
+                .get("flags")
+                .and_then(|v| v.as_str())
+                .and_then(|h| u8::from_str_radix(h.trim_start_matches("0x"), 16).ok())
+                .unwrap_or(0);
+            let target = fr.get("to").and_then(|v| v.as_str()).unwrap_or("(none)");
+            let value = fr.get("value").and_then(|v| v.as_str()).unwrap_or("0x0");
+            let data_len = fr
+                .get("data")
+                .and_then(|v| v.as_str())
+                .map(|d| d.trim_start_matches("0x").len() / 2)
+                .unwrap_or(0);
+            format!(
+                "{} [{}] -> {target}  value {value}  data {data_len}B",
+                mode_name(mode),
+                flags_desc(flags)
+            )
+        } else {
+            "(frame body unavailable)".to_string()
+        };
+
+        // Per-frame result (from the receipt).
+        let result_str = if let Some(rr) = result {
+            let ok = match rr.get("status").and_then(|v| v.as_str()).unwrap_or("?") {
+                "0x1" => "\u{2713}",
+                "0x0" => "\u{2717}",
                 other => other,
             };
-            let gas = fr.get("gasUsed").and_then(|v| v.as_str()).unwrap_or("?");
-            let logs_count = fr
+            let gas = rr.get("gasUsed").and_then(|v| v.as_str()).unwrap_or("?");
+            let logs = rr
                 .get("logs")
                 .and_then(|v| v.as_array())
                 .map(|a| a.len())
                 .unwrap_or(0);
-            println!("  Frame {i}: {st}, gas={gas}, logs={logs_count}");
-        }
+            format!("{ok} gas {gas}, {logs} logs")
+        } else {
+            "(no result)".to_string()
+        };
+
+        println!("    [{i}] {header}");
+        println!("        {result_str}");
     }
 }
 
@@ -621,105 +662,86 @@ mod tests {
         assert_eq!(parse_amount("100").unwrap(), U256::from(100u64));
     }
 
-    #[test]
-    fn encode_sender_calls_single_transfer_layout() {
-        let recipient = Address::from_str("0x0000000000000000000000000000000000c0ffee").unwrap();
-        let encoded = encode_sender_calls(&[(
-            recipient,
-            U256::from(10_000_000_000_000_000u64),
-            Bytes::new(),
-        )]);
-        // Inner list = [address(21 RLP), uint 10^16 (8 RLP), 0x80] = 30 bytes body
-        //   -> prefix 0xde (0xc0 + 30) -> 31 bytes total.
-        // Outer list = the 31-byte inner -> prefix 0xdf (0xc0 + 31) -> 32 bytes.
-        assert_eq!(encoded.len(), 32);
-        assert_eq!(encoded[0], 0xc0 + 31);
-        assert_eq!(encoded[1], 0xc0 + 30);
-    }
-
-    #[test]
-    fn sig_hash_elides_verify_data() {
-        let tx_a = FrameTx {
+    fn self_verify_tx() -> FrameTransaction {
+        FrameTransaction {
             chain_id: 1,
             nonce: 0,
             sender: sender_addr(),
-            frames: vec![Frame {
-                mode: EXEC_MODE_VERIFY,
-                flags: FLAG_BOTH,
-                target: sender_addr(),
-                gas_limit: 100_000,
-                data: Bytes::from(vec![0xaa; 66]),
-            }],
-            max_priority_fee_per_gas: U256::from(1u64),
-            max_fee_per_gas: U256::from(2u64),
+            frames: vec![
+                Frame {
+                    mode: MODE_VERIFY,
+                    flags: FLAG_BOTH,
+                    target: Some(sender_addr()),
+                    gas_limit: 100_000,
+                    value: U256::zero(),
+                    data: Bytes::new(),
+                },
+                Frame {
+                    mode: MODE_SENDER,
+                    flags: 0,
+                    target: Some(sender_addr()),
+                    gas_limit: 30_000,
+                    value: U256::from(1u64),
+                    data: Bytes::new(),
+                },
+            ],
+            signatures: vec![signature_placeholder(sender_addr())],
+            max_priority_fee_per_gas: 1,
+            max_fee_per_gas: 2,
             max_fee_per_blob_gas: U256::zero(),
             blob_versioned_hashes: Vec::new(),
-        };
-        let mut tx_b = tx_a.clone();
-        tx_b.frames[0].data = Bytes::from(vec![0xbb; 66]);
-        assert_eq!(tx_a.sig_hash(), tx_b.sig_hash());
-        assert_ne!(tx_a.to_raw(), tx_b.to_raw());
-    }
-
-    #[test]
-    fn sig_hash_covers_sender_frame_data() {
-        let base = FrameTx {
-            chain_id: 1,
-            nonce: 0,
-            sender: sender_addr(),
-            frames: vec![Frame {
-                mode: EXEC_MODE_SENDER,
-                flags: 0,
-                target: sender_addr(),
-                gas_limit: 100_000,
-                data: Bytes::from(vec![0x11; 4]),
-            }],
-            max_priority_fee_per_gas: U256::from(1u64),
-            max_fee_per_gas: U256::from(2u64),
-            max_fee_per_blob_gas: U256::zero(),
-            blob_versioned_hashes: Vec::new(),
-        };
-        let mut other = base.clone();
-        other.frames[0].data = Bytes::from(vec![0x22; 4]);
-        assert_ne!(base.sig_hash(), other.sig_hash());
-    }
-
-    #[test]
-    fn default_eoa_verify_data_layout() {
-        let sig_hash = H256::from_low_u64_be(42);
-        let sk = SecretKey::from_slice(&[0x11; 32]).unwrap();
-        let out = default_eoa_verify_data(sig_hash, &sk);
-        assert_eq!(out.len(), 66);
-        assert_eq!(out[0], 0x00);
-        assert!(out[1] == 27 || out[1] == 28);
-    }
-
-    #[test]
-    fn paymaster_owner_verify_data_layout() {
-        // CanonicalPaymaster expects exactly r(32) || s(32) || v(1) = 65 bytes.
-        let sig_hash = H256::from_low_u64_be(42);
-        let sk = SecretKey::from_slice(&[0x22; 32]).unwrap();
-        let out = paymaster_owner_verify_data(sig_hash, &sk);
-        assert_eq!(out.len(), 65);
-        // v sits at the tail, already +27.
-        assert!(out[64] == 27 || out[64] == 28);
-        // Two different hashes should produce different signatures.
-        let other = paymaster_owner_verify_data(H256::from_low_u64_be(43), &sk);
-        assert_ne!(out, other);
+            ..Default::default()
+        }
     }
 
     #[test]
     fn envelope_starts_with_0x06() {
-        let tx = FrameTx {
-            chain_id: 1,
-            nonce: 0,
-            sender: sender_addr(),
-            frames: vec![],
-            max_priority_fee_per_gas: U256::zero(),
-            max_fee_per_gas: U256::zero(),
-            max_fee_per_blob_gas: U256::zero(),
-            blob_versioned_hashes: Vec::new(),
-        };
-        assert_eq!(tx.to_raw()[0], 0x06);
+        let raw = raw_canonical(self_verify_tx());
+        assert_eq!(raw[0], 0x06);
+    }
+
+    #[test]
+    fn sig_hash_elides_empty_msg_signature_bytes() {
+        // Empty-msg signature bytes must not change the sig_hash (so we can
+        // compute it with a placeholder and fill the real bytes afterward).
+        let mut a = self_verify_tx();
+        let mut b = self_verify_tx();
+        a.signatures[0].signature = Bytes::from(vec![0xaa; 65]);
+        b.signatures[0].signature = Bytes::from(vec![0xbb; 65]);
+        assert_eq!(a.compute_sig_hash(), b.compute_sig_hash());
+    }
+
+    #[test]
+    fn sig_hash_covers_sender_frame_value() {
+        let a = self_verify_tx();
+        let mut b = self_verify_tx();
+        b.frames[1].value = U256::from(2u64);
+        assert_ne!(a.compute_sig_hash(), b.compute_sig_hash());
+    }
+
+    #[test]
+    fn secp256k1_signature_is_v_r_s() {
+        let sig_hash = H256::from_low_u64_be(42);
+        let sk = SecretKey::from_slice(&[0x11; 32]).unwrap();
+        let signer = sender_addr();
+        let fs = secp256k1_signature(sig_hash, signer, &sk);
+        assert_eq!(fs.scheme, FRAME_SIG_SCHEME_SECP256K1);
+        assert_eq!(fs.signer, signer);
+        assert!(fs.msg.is_empty());
+        assert_eq!(fs.signature.len(), 65);
+        // v sits at byte 0 (ethrex parses v || r || s), already +27.
+        assert!(fs.signature[0] == 27 || fs.signature[0] == 28);
+    }
+
+    #[test]
+    fn flags_and_mode_decode() {
+        assert_eq!(mode_name(MODE_VERIFY), "VERIFY");
+        assert_eq!(mode_name(MODE_SENDER), "SENDER");
+        assert_eq!(mode_name(3), "RESERVED");
+        assert_eq!(flags_desc(FLAG_BOTH), "APPROVE execution+payment");
+        assert_eq!(
+            flags_desc(FLAG_PAYMENT | FLAG_ATOMIC_BATCH),
+            "APPROVE payment, atomic-batch"
+        );
     }
 }


### PR DESCRIPTION
**Motivation**

rex v21.0.0 pairs with ethrex v21.0.0 — the first release that ships the EIP-8141 `FrameTransaction` type. The current `frame` command hand-rolls its own frame structs + RLP in a stale wire format: it still *compiles* against ethrex 21 (it only borrows a few primitive types), but every transaction it builds is rejected on-chain — a silent failure. v21 must fix this or it ships a broken `frame` command.

**Description**

1. **Bump** the 7 ethrex crates.io deps + workspace version to `21.0.0`, and the CI integration ethrex binary to v21.0.0.
2. **Rewrite** `cli/src/commands/frame.rs` onto ethrex's canonical `FrameTransaction` / `Frame` / `FrameSignature` types (EIP-8141 only — single scalar nonce; no keyed nonces / recent-root-references):
   - Top-level `signatures: Vec<FrameSignature>`; VERIFY frame data empty (was: signature stuffed into VERIFY frame data).
   - 6-field frames `{mode, flags, target, gas_limit, value, data}`; SENDER frames carry value/data directly (was: 5-field, RLP call-list in data).
   - secp256k1 signatures reordered `r‖s‖v` → `v‖r‖s` (v = recovery_id + 27).
   - Sign `compute_sig_hash()` with empty-bytes signature placeholders, then fill the real bytes.
   - Emit the raw `0x06` tx via `Transaction::FrameTransaction(tx).encode_canonical_to_vec()`.
   - `Send`/`Build` preserved; `Receipt` → `Inspect` (alias `receipt`) with a decoded frame-by-frame viewer. Added `frame` to the README command list.

Verified locally against ethrex 21.0.0: `cargo check --workspace`, `cargo clippy`, `cargo fmt --check` clean; 6 frame unit tests pass (incl. the `sig_hash` empty-msg-elision and `v‖r‖s` ordering invariants).

> ⚠️ **Draft — do not merge yet.** Stacked after #242 (v20). Once v20 merges I'll rebase this onto `main` (version delta becomes 20→21) and mark it ready for review.
