### PR TITLE
chore(cli,sdk): bump ethrex version to v23.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c9bc2b90801af7c1b928b113eb23de8b26619a33c2f7c94637a21d0b0db85"
+checksum = "ab4468dc986cea66fe4d6f4b846c52e8f9438103c07f86c347b718db98e8ee94"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce09f8622793b15319d0f080893e17000eb23a4973b9543484b3494be566f04c"
+checksum = "90cbe0d61a9f9fdb3c2795abeda0b711e6dff0dc67f0fe543aab4e2463927026"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f28907cef2a333bb1b4903894d66cd281ce917befa6c363ed4884c4956ef51a"
+checksum = "e88d1bd052fe0b42002cd43c2a4ac92316fd4c55c57d20d989a33c65052c5c32"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54d638c533f56e7af23c453eb1d7e822f76f38adfd15f13b222048c09f59aa66"
+checksum = "3f4be7c0d04944dd4b3bf725e8101352628acc06e37e913abe869564a5c61888"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e82155af49332144cf69bdb8ba51eedf76ba6b0c625f60536803e940fab3af1"
+checksum = "b25957b65d702e4a4382c9fee5122acb4ef105b7357fb1100af7f06897873bd2"
 dependencies = [
  "axum",
  "bytes",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4a93f93c9749a482adbe6ea726c46b20f4fc699edfb3b1ec945316bab0e140"
+checksum = "bb5ee2c4edc3ce6c76466a4bc471b3e7f796b9ced1d50171a4ed12442bd3df28"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1390,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c47299846020bff66fbbf2abbbdd17ed3fcf3b3ff45df4a012038036ddc1a4a"
+checksum = "d8c2b0fa6ae6aebbde6464d7500aa89ab416699d86a3f3abe2600406a2849a2c"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1407,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789e55eabcd9b72b5c22b46355dcf2c00fe19619ff4e067edb8c6c77a904e2b0"
+checksum = "992a64b49edc4ef929c1f2f7211a2bcc26690d3720fe7a5514036cabb4792841"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1452,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5b7f771586f2f2c406f028a836049d6962e228ea56fd217c2dadf443be3b95"
+checksum = "d717b8f86f258435fff828c363c1a87fef6fc64d7375d505072065880fca6f28"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5887b046198cbcb9c918e20d1f3f9bb1f3f9b0ea297b42d2528a834bf8a47a"
+checksum = "cd9c584b7e73b119d1a0fb02f4e36a9fa27b58403fe603a8d601dbd415175b1e"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1504,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442deb1ce67361b4f00ffe2d313d45c9061e3aad3b8db76ff6d54342d0ed590d"
+checksum = "b0daa73682fa9f21e97c6263d812490b9e9b46db01e45897200078745486ec68"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6324c52a155c8ae7d3dc76d320842c5f89da989bd3c5a5cfcb7e5447472e740"
+checksum = "bd8aa08a26f28cb7082a816e73f287e2a3a25da0375c1ba4d3229d612aa4e757"
 dependencies = [
  "thiserror 2.0.17",
  "tracing",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4048d2b5a2490f723198af1ee9d0d04d985db7b45e01b1c542bd6d87b29e74ec"
+checksum = "8ec5f5391acd4634a1643dfe28db7ebb5166ebbc8f2df543bcf848cc5f763eed"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65b764ba06f7b9df16fc49f43b1c0e61e246dbdf77affffde0ed7710f77bad7"
+checksum = "225cb6a72342ac950356cd139bab89eea829402035b4d2c2e34ffab131673b8d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b27609accdf673d4251e80f275b0a5b2583d49a38a93bfa37e36f30051e72b"
+checksum = "618c0341b11641448cdbb33e04cf3d6f3b3b4b1edbbe117d386f793b4d87c17c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b132c621ef2f2e5628d8375136b48732dd06c4c8ed63ffe68503e4dd902ce08"
+checksum = "a9bfa53f420d193a594c238470fbae6097cafcf942dc3d362c737b369c500dea"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "rex"
-version = "22.0.0"
+version = "23.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "rex-sdk"
-version = "22.0.0"
+version = "23.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["cli"]
 resolver = "3"
 
 [workspace.package]
-version = "22.0.0"
+version = "23.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/lambdaclass/rex"
@@ -32,13 +32,13 @@ manual_saturating_arithmetic = "warn"
 rex-cli = { path = "cli" }
 rex-sdk = { path = "sdk" }
 
-ethrex-common = "22.0.0"
-ethrex-blockchain = "22.0.0"
-ethrex-rlp = "22.0.0"
-ethrex-rpc = "22.0.0"
-ethrex-l2-rpc = "22.0.0"
-ethrex-sdk = "22.0.0"
-ethrex-l2-common = "22.0.0"
+ethrex-common = "23.0.0"
+ethrex-blockchain = "23.0.0"
+ethrex-rlp = "23.0.0"
+ethrex-rpc = "23.0.0"
+ethrex-l2-rpc = "23.0.0"
+ethrex-sdk = "23.0.0"
+ethrex-l2-common = "23.0.0"
 
 keccak-hash = "0.11.0"
 thiserror = "2.0.11"


### PR DESCRIPTION
Bump the workspace version and every `ethrex-*` dependency pin to the crates published by the [ethrex v23.0.0 release](https://github.com/lambdaclass/ethrex/releases/tag/v23.0.0). `cargo check --workspace` passes; lockfile diff is version+checksum only. Counterpart release per the ethrex release process.